### PR TITLE
Support SQL Azure databases

### DIFF
--- a/src/DbUp/Support/SqlServer/SqlTableJournal.cs
+++ b/src/DbUp/Support/SqlServer/SqlTableJournal.cs
@@ -85,7 +85,7 @@ namespace DbUp.Support.SqlServer
                 {
                     command.CommandText = string.Format(
 @"create table {0} (
-	[Id] int identity(1,1) not null constraint PK_SchemaVersions_Id primary key nonclustered ,
+	[Id] int identity(1,1) not null constraint PK_SchemaVersions_Id primary key clustered ,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
 )", schemaTableName);


### PR DESCRIPTION
SQL Azure requires all tables to have a clustered index. This commit
changes the primary key on the SchemaVersions table from non-clustered
to clustered.
