### PR TITLE
Added ability to turn off variable preprocessing.

### DIFF
--- a/src/DbUp.Specification/UpgradeEngineTests.cs
+++ b/src/DbUp.Specification/UpgradeEngineTests.cs
@@ -28,7 +28,7 @@ namespace DbUp.Specification
                 dbConnection = Substitute.For<IDbConnection>();
                 dbCommand = Substitute.For<IDbCommand>();
                 dbConnection.CreateCommand().Returns(dbCommand);
-                scriptExecutor = new SqlScriptExecutor(()=>dbConnection, ()=>new TraceUpgradeLog(), null, null);
+                scriptExecutor = new SqlScriptExecutor(()=>dbConnection, ()=>new TraceUpgradeLog(), null, () => true, null);
 
                 var builder = new UpgradeEngineBuilder()
                     .WithScript(new SqlScript("1234", "create table $var$ (Id int)"))

--- a/src/DbUp.SqlCe/SqlCeExtensions.cs
+++ b/src/DbUp.SqlCe/SqlCeExtensions.cs
@@ -26,7 +26,7 @@ public static class SqlCeExtensions
     {
         var builder = new UpgradeEngineBuilder();
         builder.Configure(c => c.ConnectionFactory = connectionFactory);
-        builder.Configure(c => c.ScriptExecutor = new SqlScriptExecutor(c.ConnectionFactory, () => c.Log, null, c.ScriptPreprocessors));
+        builder.Configure(c => c.ScriptExecutor = new SqlScriptExecutor(c.ConnectionFactory, () => c.Log, null, () => c.VariablesEnabled, c.ScriptPreprocessors));
         builder.Configure(c => c.Journal = new SqlTableJournal(c.ConnectionFactory, null, "SchemaVersions", c.Log));
         builder.WithPreprocessor(new SqlCePreprocessor());
         return builder;

--- a/src/DbUp.sln
+++ b/src/DbUp.sln
@@ -10,7 +10,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Information", "Information", "{FA530374-E28B-419B-BCA2-82A0512774F2}"
 	ProjectSection(SolutionItems) = preProject
 		Information\SolutionInfo.cs = Information\SolutionInfo.cs
-		Information\VersionInfo.cs = Information\VersionInfo.cs
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbUp.Specification", "DbUp.Specification\DbUp.Specification.csproj", "{80A9E08A-13F3-4721-9849-C55167FE21A5}"

--- a/src/DbUp/Builder/StandardExtensions.cs
+++ b/src/DbUp/Builder/StandardExtensions.cs
@@ -242,5 +242,27 @@ public static class StandardExtensions
     {
         return WithVariables(builder, new Dictionary<string, string> { { variableName, value } });
     }
+
+    /// <summary>
+    /// Sets a configuration flag which will cause the engine to skip variable expansion.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <returns></returns>
+    public static UpgradeEngineBuilder WithVariablesDisabled(this UpgradeEngineBuilder builder)
+    {
+        builder.Configure(c => c.VariablesEnabled = false);
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets a configuration flag which will cause the engine to perform variable expansion.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <returns></returns>
+    public static UpgradeEngineBuilder WithVariablesEnabled(this UpgradeEngineBuilder builder)
+    {
+        builder.Configure(c => c.VariablesEnabled = true);
+        return builder;
+    }
 }
 

--- a/src/DbUp/Builder/UpgradeConfiguration.cs
+++ b/src/DbUp/Builder/UpgradeConfiguration.cs
@@ -21,6 +21,7 @@ namespace DbUp.Builder
         public UpgradeConfiguration()
         {
             Log = new TraceUpgradeLog();
+            VariablesEnabled = true;
         }
 
         /// <summary>
@@ -63,6 +64,11 @@ namespace DbUp.Builder
         {
             get { return variables; }
         }
+
+        /// <summary>
+        /// Determines if variables should be replaced in scripts before they are run.
+        /// </summary>
+        public bool VariablesEnabled { get; set; }
 
         /// <summary>
         /// Ensures all expectations have been met regarding this configuration.

--- a/src/DbUp/Helpers/TemporarySqlDatabase.cs
+++ b/src/DbUp/Helpers/TemporarySqlDatabase.cs
@@ -23,12 +23,12 @@ namespace DbUp.Helpers
         {
             databaseName = name;
             connectionString = string.Format("Server=(local)\\SQLEXPRESS;Database={0};Trusted_connection=true;Pooling=false", databaseName);
-            database = new AdHocSqlRunner(( ) => new SqlConnection(connectionString), "dbo");
+            database = new AdHocSqlRunner(( ) => new SqlConnection(connectionString), "dbo", () => true);
 
             var builder = new SqlConnectionStringBuilder(connectionString);
             builder.InitialCatalog = "master";
 
-            master = new AdHocSqlRunner(() => new SqlConnection(builder.ToString()), "dbo");
+            master = new AdHocSqlRunner(() => new SqlConnection(builder.ToString()), "dbo", () => true);
         }
 
         /// <summary>

--- a/src/DbUp/Support/SqlServer/SqlServerExtensions.cs
+++ b/src/DbUp/Support/SqlServer/SqlServerExtensions.cs
@@ -67,7 +67,7 @@ public static class SqlServerExtensions
     {
         var builder = new UpgradeEngineBuilder();
         builder.Configure(c => c.ConnectionFactory = connectionFactory);
-        builder.Configure(c => c.ScriptExecutor = new SqlScriptExecutor(c.ConnectionFactory, () => c.Log, schema, c.ScriptPreprocessors));
+        builder.Configure(c => c.ScriptExecutor = new SqlScriptExecutor(c.ConnectionFactory, () => c.Log, schema, () => c.VariablesEnabled, c.ScriptPreprocessors));
         builder.Configure(c => c.Journal = new SqlTableJournal(c.ConnectionFactory, schema, "SchemaVersions", c.Log));
         return builder;
     }


### PR DESCRIPTION
A SQL Script I wanted to run through DbUp used strings with "$<something>$" within them. This issue is referenced in [a post on the Google Group](https://groups.google.com/forum/?fromgroups#!topic/dbup-discuss/Ja0vUisS_Fg).

My solution involves a new property on the configuration "VariablesEnabled" which is passed into the IScriptExecutor enabling it to skip the VariableSubstitutionPreprocessor if it is "false".

If someone wants to tell me how not to screw up line endings on this particular project (cause pretty sure I have here judging by the diffs) that'd be awesome.
