### PR TITLE
Adds "WithExecutionTimeout" helper for setting script timeout.

### DIFF
--- a/src/DbUp.Specification/BuilderTests.cs
+++ b/src/DbUp.Specification/BuilderTests.cs
@@ -18,7 +18,7 @@ namespace DbUp.Specification
             connection.CreateCommand().Returns(command);
 
             var upgradeEngine = DeployChanges.To
-                .SqlDatabase(()=>connection, "Db")
+                .SqlDatabase(() => connection, "Db")
                 .WithScript("testscript", "$schema$Up $somevar$")
                 .JournalTo(journal)
                 .WithVariable("somevar", "is awesome")
@@ -27,6 +27,63 @@ namespace DbUp.Specification
             upgradeEngine.PerformUpgrade();
 
             Assert.AreEqual("[Db]Up is awesome", command.CommandText);
+        }
+
+        [Test]
+        public void WithExecutionTimeout_Should_Set_CommandTimeout_Property_To_Given_Value()
+        {
+            var journal = Substitute.For<IJournal>();
+            var connection = Substitute.For<IDbConnection>();
+            var command = Substitute.For<IDbCommand>();
+            connection.CreateCommand().Returns(command);
+
+            var upgradeEngine = DeployChanges.To
+                .SqlDatabase(() => connection)
+                .WithScript("testscript", "test")
+                .JournalTo(journal)
+                .WithExecutionTimeout(TimeSpan.FromSeconds(45))
+                .Build();
+
+            upgradeEngine.PerformUpgrade();
+
+            Assert.AreEqual(45, command.CommandTimeout);
+        }
+
+        [Test]
+        public void WithExecutionTimeout_Should_Not_Set_CommandTimeout_Property_For_Null()
+        {
+            var journal = Substitute.For<IJournal>();
+            var connection = Substitute.For<IDbConnection>();
+            var command = Substitute.For<IDbCommand>();
+            connection.CreateCommand().Returns(command);
+
+            var upgradeEngine = DeployChanges.To
+                .SqlDatabase(() => connection)
+                .WithScript("testscript", "test")
+                .JournalTo(journal)
+                .WithExecutionTimeout(null)
+                .Build();
+
+            upgradeEngine.PerformUpgrade();
+
+            Assert.AreEqual(0, command.CommandTimeout);
+        }
+
+
+        [Test, ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void WithExecutionTimeout_Should_Not_Allow_Negative_Timeout_Values()
+        {
+            var journal = Substitute.For<IJournal>();
+            var connection = Substitute.For<IDbConnection>();
+            var command = Substitute.For<IDbCommand>();
+            connection.CreateCommand().Returns(command);
+
+            var upgradeEngine = DeployChanges.To
+                .SqlDatabase(() => connection)
+                .WithScript("testscript", "test")
+                .JournalTo(journal)
+                .WithExecutionTimeout(TimeSpan.FromSeconds(-5))
+                .Build();
         }
     }
 }

--- a/src/DbUp/Builder/StandardExtensions.cs
+++ b/src/DbUp/Builder/StandardExtensions.cs
@@ -264,5 +264,28 @@ public static class StandardExtensions
         builder.Configure(c => c.VariablesEnabled = true);
         return builder;
     }
-}
 
+    /// <summary>
+    /// Allows you to set the execution timeout for scripts.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="timeout">A <c>TimeSpan</c> value containing the timeout value or <c>null</c>.</param>
+    /// <exception cref="System.ArgumentOutOfRangeException">The timeout value is less than zero or greater than 2,147,483,647 seconds.</exception>
+    /// <remarks>Setting the timeout parameter to <c>null</c> will use the default timeout of the underlying provider.</remarks>
+    /// <returns></returns>
+    public static UpgradeEngineBuilder WithExecutionTimeout(this UpgradeEngineBuilder builder, TimeSpan? timeout)
+    {
+        if (timeout == null)
+        {
+            builder.Configure(c => c.ScriptExecutor.ExecutionTimeoutSeconds = null);
+            return builder;
+        }
+
+        var totalSeconds = timeout.Value.TotalSeconds;
+
+        if ((0 > totalSeconds) || (totalSeconds > int.MaxValue)) throw new ArgumentOutOfRangeException("timeout", timeout, string.Format("The timeout value must be a value between 1 and {0} seconds", int.MaxValue));
+
+        builder.Configure(c => c.ScriptExecutor.ExecutionTimeoutSeconds = Convert.ToInt32(totalSeconds));
+        return builder;
+    }
+}


### PR DESCRIPTION
This is a small addition to the configuration extension methods to allow users to set the execution timeout if they have migration operations which take longer than the default (which for SQL Server is 30 seconds).
