### PR TITLE
Another simpler approach for introducing transaction support

### DIFF
--- a/src/DbUp/Builder/StandardExtensions.cs
+++ b/src/DbUp/Builder/StandardExtensions.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using DbUp.Builder;
 using DbUp.Engine;
 using DbUp.Engine.Output;
+using DbUp.Engine.Transactions;
 using DbUp.ScriptProviders;
 
 /// <summary>
@@ -286,6 +287,24 @@ public static class StandardExtensions
         if ((0 > totalSeconds) || (totalSeconds > int.MaxValue)) throw new ArgumentOutOfRangeException("timeout", timeout, string.Format("The timeout value must be a value between 1 and {0} seconds", int.MaxValue));
 
         builder.Configure(c => c.ScriptExecutor.ExecutionTimeoutSeconds = Convert.ToInt32(totalSeconds));
+        return builder;
+    }
+
+    /// <summary>
+    /// Tells DbUp to use a single transaction around this upgrade
+    /// </summary>
+    public static UpgradeEngineBuilder WithTransaction(this UpgradeEngineBuilder builder)
+    {
+        builder.Configure(c => c.TransactionMode = TransactionMode.SingleTransaction);
+        return builder;
+    }
+
+    /// <summary>
+    /// Tells DbUp not to use a transaction (default)
+    /// </summary>
+    public static UpgradeEngineBuilder WithNoTransaction(this UpgradeEngineBuilder builder)
+    {
+        builder.Configure(c => c.TransactionMode = TransactionMode.NoTransaction);
         return builder;
     }
 }

--- a/src/DbUp/Builder/UpgradeConfiguration.cs
+++ b/src/DbUp/Builder/UpgradeConfiguration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using DbUp.Engine;
 using DbUp.Engine.Output;
+using DbUp.Engine.Transactions;
 
 namespace DbUp.Builder
 {
@@ -69,6 +70,11 @@ namespace DbUp.Builder
         /// Determines if variables should be replaced in scripts before they are run.
         /// </summary>
         public bool VariablesEnabled { get; set; }
+
+        /// <summary>
+        /// Determines what transaction strategy DbUp uses
+        /// </summary>
+        public TransactionMode TransactionMode { get; set; }
 
         /// <summary>
         /// Ensures all expectations have been met regarding this configuration.

--- a/src/DbUp/DbUp.csproj
+++ b/src/DbUp/DbUp.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Engine\IScript.cs" />
     <Compile Include="Engine\LazySqlScript.cs" />
     <Compile Include="Engine\Preprocessors\StripSchemaPreprocessor.cs" />
+    <Compile Include="Engine\Transactions\TransactionMode.cs" />
     <Compile Include="Helpers\AdHocSqlRunner.cs" />
     <Compile Include="Engine\Output\ConsoleUpgradeLog.cs" />
     <Compile Include="Engine\UpgradeEngine.cs" />

--- a/src/DbUp/Engine/Transactions/TransactionMode.cs
+++ b/src/DbUp/Engine/Transactions/TransactionMode.cs
@@ -1,0 +1,18 @@
+﻿namespace DbUp.Engine.Transactions
+{
+    /// <summary>
+    /// The transaction strategy to use
+    /// </summary>
+    public enum TransactionMode
+    {
+        /// <summary>
+        /// Run creates a new connection for each script, without a transaction
+        /// </summary>
+        NoTransaction,
+ 
+        /// <summary>
+        /// DbUp will run using a single transaction for the whole upgrade operation
+        /// </summary>
+        SingleTransaction,
+    }
+}


### PR DESCRIPTION
This is an alternative to #16

It doesn't have the option to have a transaction per script, and will not be extensible.

What does everyone think?
