### PR TITLE
Fixed bug in SqlTableJournal to use 24h format instead of 12h format.

### DIFF
--- a/src/DbUp/Support/SqlServer/SqlTableJournal.cs
+++ b/src/DbUp/Support/SqlServer/SqlTableJournal.cs
@@ -103,7 +103,7 @@ namespace DbUp.Support.SqlServer
             using (var connection = connectionFactory())
             using (var command = connection.CreateCommand())
             {
-                command.CommandText = string.Format("insert into {0} (ScriptName, Applied) values (@scriptName, '{1}')", schemaTableName, DateTime.UtcNow.ToString("yyyy-MM-dd hh:mm:ss"));
+                command.CommandText = string.Format("insert into {0} (ScriptName, Applied) values (@scriptName, '{1}')", schemaTableName, DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss"));
                 
                 var param = command.CreateParameter();
                 param.ParameterName = "scriptName";


### PR DESCRIPTION
We were sorting by that field and found a bug where scripts in the afternoon were sorted wrong.

Another option in the log would be to include "AM" or "PM".
Or maybe even better, use  'DateTime.UtcNow.ToString("s")'
