### PR TITLE
Explicitly specify "Read" for file access.

### DIFF
--- a/src/DbUp/Engine/SqlScript.cs
+++ b/src/DbUp/Engine/SqlScript.cs
@@ -48,7 +48,7 @@ namespace DbUp.Engine
         /// <returns></returns>
         public static SqlScript FromFile(string path)
         {
-            using (FileStream fileStream = new FileStream(path, FileMode.Open))
+            using (FileStream fileStream = new FileStream(path, FileMode.Open, FileAccess.Read))
             {
                 var fileName = new FileInfo(path).Name;
                 return FromStream(fileName, fileStream);


### PR DESCRIPTION
Explicitly specify "Read" for file access to allow scripts to be marked "ReadOnly". Fixes #46

No unit tests as this method isn't currently tested.
