### PR TITLE
Fixes to SqlServer script logging

### DIFF
--- a/src/DbUp/Support/SqlServer/SqlScriptExecutor.cs
+++ b/src/DbUp/Support/SqlServer/SqlScriptExecutor.cs
@@ -181,7 +181,7 @@ namespace DbUp.Support.SqlServer
                 for (int i = 0; i < reader.FieldCount; i++)
                 {
                     // need to handle no rows, short names with long data, and long names with short data
-                    int maxLength = (lines.Any() ? lines.Max(l => Math.Max(names[i].Length, l[i].Length)) : names[i].Length) + 2;
+                    int maxLength = (lines.Any() ? lines.Max(l => Math.Max(names[i].Length, l[i] == null ? 0 : l[i].Length)) : names[i].Length) + 2;
                     format += " {" + i + ", " + maxLength + "} |";
                     totalLength += (maxLength + 3);
                 }


### PR DESCRIPTION
When script output logging is enabled on the SqlScriptExecutor, it blows
up on statements that don't return any rows (InvalidOperationException:
"sequence contains no elements" from the Max call). It also spews a lot
of noise on scalar statements (prints parts of the empty header table).
Fixed those issues. Also cleaned up the case where the header table is
malformed when a column name is longer than the row data in each column
(including when there's no row data).
