### PR TITLE
Fix for null line error when rendering output

### DIFF
--- a/src/DbUp/Support/SqlServer/SqlScriptExecutor.cs
+++ b/src/DbUp/Support/SqlServer/SqlScriptExecutor.cs
@@ -175,7 +175,7 @@ namespace DbUp.Support.SqlServer
                 int totalLength = 0;
                 for (int i = 0; i < reader.FieldCount; i++)
                 {
-                    int maxLength = lines.Max(l => l[i].Length) + 2;
+                    int maxLength = lines.Max(l => (l[i] ?? "").Length) + 2;
                     format += " {" + i + ", " + maxLength + "} |";
                     totalLength += (maxLength + 3);
                 }


### PR DESCRIPTION
Sometimes the line can be null when rendering output when log to console is enabled. A good example is when executing a merge statement and outputting a line at the end of the merge statement like "OUTPUT $action, inserted._, deleted._;" I was encountering this error while programming. 
