### PR TITLE
Add support for Excluded Scripts and running a Single File

### DIFF
--- a/src/DbUp.Tests/UpgradeDatabaseScenarios.cs
+++ b/src/DbUp.Tests/UpgradeDatabaseScenarios.cs
@@ -40,7 +40,8 @@ namespace DbUp.Tests
             {
                 new SqlScript("Script1.sql", "create table Foo (Id int identity)"),
                 new SqlScript("Script2.sql", "alter table Foo add column Name varchar(255)"),
-                new SqlScript("Script3.sql", "insert into Foo (Name) values ('test')")
+                new SqlScript("Script3.sql", "insert into Foo (Name) values ('test')"),
+                new SqlScript("Script4.sql", "weird oracle commands"),
             };
             database = new TemporarySQLiteDatabase("IntegrationScenarios");
             upgradeEngineBuilder = DeployChanges.To
@@ -243,6 +244,11 @@ namespace DbUp.Tests
             public IEnumerable<SqlScript> GetScripts(IConnectionManager connectionManager)
             {
                 return sqlScripts;
+            }
+
+            public string[] GetExcludedScripts()
+            {
+                return new[] {"Script4.sql"};
             }
         }
     }

--- a/src/DbUp/Builder/StandardExtensions.cs
+++ b/src/DbUp/Builder/StandardExtensions.cs
@@ -101,12 +101,13 @@ public static class StandardExtensions
     /// </summary>
     /// <param name="builder">The builder.</param>
     /// <param name="scripts">The scripts.</param>
+    /// <param name="excludedScripts">Scripts to be excluded</param>
     /// <returns>
     /// The same builder
     /// </returns>
-    public static UpgradeEngineBuilder WithScripts(this UpgradeEngineBuilder builder, IEnumerable<SqlScript> scripts)
+    public static UpgradeEngineBuilder WithScripts(this UpgradeEngineBuilder builder, IEnumerable<SqlScript> scripts, IEnumerable<string> excludedScripts)
     {
-        return WithScripts(builder, new StaticScriptProvider(scripts));
+        return WithScripts(builder, new StaticScriptProvider(scripts, excludedScripts));
     }
 
     /// <summary>
@@ -119,7 +120,7 @@ public static class StandardExtensions
     /// </returns>
     public static UpgradeEngineBuilder WithScripts(this UpgradeEngineBuilder builder, params SqlScript[] scripts)
     {
-        return WithScripts(builder, (IEnumerable<SqlScript>)scripts);
+        return WithScripts(builder, scripts, null);
     }
 
     /// <summary>

--- a/src/DbUp/Engine/IScriptProvider.cs
+++ b/src/DbUp/Engine/IScriptProvider.cs
@@ -13,5 +13,11 @@ namespace DbUp.Engine
         /// Gets all scripts that should be executed.
         /// </summary>
         IEnumerable<SqlScript> GetScripts(IConnectionManager connectionManager);
+
+        /// <summary>
+        /// Gets scripts to be excluded from all deployments
+        /// </summary>
+        /// <returns></returns>
+        string[] GetExcludedScripts();
     }
 }

--- a/src/DbUp/Engine/UpgradeEngine.cs
+++ b/src/DbUp/Engine/UpgradeEngine.cs
@@ -112,10 +112,19 @@ namespace DbUp.Engine
 
         private List<SqlScript> GetScriptsToExecuteInsideOperation()
         {
-            var allScripts = configuration.ScriptProviders.SelectMany(scriptProvider => scriptProvider.GetScripts(configuration.ConnectionManager));
-            var executedScripts = configuration.Journal.GetExecutedScripts();
+            IEnumerable<SqlScript> allScripts = configuration.ScriptProviders.SelectMany(
+                scriptProvider => scriptProvider.GetScripts(configuration.ConnectionManager));
 
-            return allScripts.Where(s => !executedScripts.Any(y => y == s.Name)).ToList();
+            string[] executedScripts = configuration.Journal.GetExecutedScripts();
+
+            string[] excludedScripts = configuration.ScriptProviders.SelectMany(
+                scriptProvider => scriptProvider.GetExcludedScripts()).ToArray();
+
+            var scriptsToExecute = allScripts.Where(s => executedScripts.All(y => y != s.Name));
+
+            scriptsToExecute = scriptsToExecute.Where(s => excludedScripts.All(y => y != s.Name));
+
+            return scriptsToExecute.ToList();
         }
 
         ///<summary>

--- a/src/DbUp/ScriptProviders/EmbeddedScriptAndCodeProvider.cs
+++ b/src/DbUp/ScriptProviders/EmbeddedScriptAndCodeProvider.cs
@@ -49,5 +49,19 @@ namespace DbUp.ScriptProviders
 
             return sqlScripts;
         }
+
+        /// <summary>
+        /// Gets all scripts that should be excluded.
+        /// </summary>
+        /// <returns></returns>
+        public string[] GetExcludedScripts()
+        {
+            return assembly
+                .GetManifestResourceNames()
+                .Where(s => s.Equals("DbUpExcludedFiles.txt"))
+                .OrderBy(x => x)
+                .Select(s => s)
+                .ToArray();
+        }
     }
 }

--- a/src/DbUp/ScriptProviders/EmbeddedScriptProvider.cs
+++ b/src/DbUp/ScriptProviders/EmbeddedScriptProvider.cs
@@ -40,5 +40,18 @@ namespace DbUp.ScriptProviders
                 .ToList();
         }
 
+        /// <summary>
+        /// Gets all scripts that should be excluded.
+        /// </summary>
+        /// <returns></returns>
+        public string[] GetExcludedScripts()
+        {
+            return assembly
+                .GetManifestResourceNames()
+                .Where(s => s.Equals("DbUpExcludedFiles.txt"))
+                .OrderBy(x => x)
+                .Select(s => s)
+                .ToArray();
+        }
     }
 }

--- a/src/DbUp/ScriptProviders/FileSystemScriptProvider.cs
+++ b/src/DbUp/ScriptProviders/FileSystemScriptProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using DbUp.Engine;
 using DbUp.Engine.Transactions;
 
@@ -12,14 +13,14 @@ namespace DbUp.ScriptProviders
     ///</summary>
     public class FileSystemScriptProvider : IScriptProvider
     {
-        private readonly string directoryPath;
+        private readonly string directoryOrFilePath;
 
         ///<summary>
         ///</summary>
-        ///<param name="directoryPath">Path to SQL upgrade scripts</param>
-        public FileSystemScriptProvider(string directoryPath)
+        ///<param name="directoryOrFilePath">Path to SQL upgrade scripts</param>
+        public FileSystemScriptProvider(string directoryOrFilePath)
         {
-            this.directoryPath = directoryPath;
+            this.directoryOrFilePath = directoryOrFilePath;
         }
 
         /// <summary>
@@ -27,8 +28,27 @@ namespace DbUp.ScriptProviders
         /// </summary>
         public IEnumerable<SqlScript> GetScripts(IConnectionManager connectionManager)
         {
-            return Directory.GetFiles(directoryPath, "*.sql").Select(SqlScript.FromFile).ToList();
+            if (Directory.Exists(directoryOrFilePath))
+            {
+                return Directory.GetFiles(directoryOrFilePath, "*.sql").Select(SqlScript.FromFile).ToList();
+            }
+
+            if (File.Exists(directoryOrFilePath))
+            {
+                return new[] {SqlScript.FromFile(directoryOrFilePath)};
+            }
+
+            return new List<SqlScript>();
         }
 
+        /// <summary>
+        /// Returns excluded scripts array from DbUpExcludedFiles.txt
+        /// </summary>
+        /// <returns></returns>
+        public string[] GetExcludedScripts()
+        {
+            string filePath = Path.Combine(directoryOrFilePath, "DbUpExcludedFiles.txt");
+            return File.Exists(filePath) ? File.ReadAllLines(filePath) : new string[0];
+        }
     }
 }

--- a/src/DbUp/ScriptProviders/StaticScriptProvider.cs
+++ b/src/DbUp/ScriptProviders/StaticScriptProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DbUp.Engine;
 using DbUp.Engine.Transactions;
 
@@ -11,14 +12,17 @@ namespace DbUp.ScriptProviders
     public sealed class StaticScriptProvider : IScriptProvider
     {
         private readonly IEnumerable<SqlScript> scripts;
+        private readonly IEnumerable<string> excludedScripts;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StaticScriptProvider"/> class.
         /// </summary>
         /// <param name="scripts">The scripts.</param>
-        public StaticScriptProvider(IEnumerable<SqlScript> scripts)
+        /// <param name="excludedScripts">Scripts to be excluded</param>
+        public StaticScriptProvider(IEnumerable<SqlScript> scripts, IEnumerable<string> excludedScripts)
         {
             this.scripts = scripts;
+            this.excludedScripts = excludedScripts;
         }
 
         /// <summary>
@@ -27,6 +31,15 @@ namespace DbUp.ScriptProviders
         public IEnumerable<SqlScript> GetScripts(IConnectionManager connectionManager)
         {
             return scripts;
+        }
+
+        /// <summary>
+        /// Gets all scripts that should be excluded.
+        /// </summary>
+        /// <returns></returns>
+        public string[] GetExcludedScripts()
+        {
+            return null != excludedScripts ? excludedScripts.ToArray() : new string[0];
         }
     }
 }


### PR DESCRIPTION
Added a feature to support having a DbUpExcludedFile.txt file which includes names of SQL Scripts that should not be run, for example, database repositories that include Oracle specific files. Also, added support for running a single file instead of an entire directory of files.
