### PR TITLE
Support for selection of sql file encoding

### DIFF
--- a/src/DbUp/Builder/StandardExtensions.cs
+++ b/src/DbUp/Builder/StandardExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Text;
+using DbUp;
 using DbUp.Builder;
 using DbUp.Engine;
 using DbUp.Engine.Output;
@@ -178,6 +180,35 @@ public static class StandardExtensions
     }
 
     /// <summary>
+    /// Adds all scripts from a folder on the file system, with custom encoding.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="path">The directory path.</param>
+    /// <param name="encoding">The encoding.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsFromFileSystem(this UpgradeEngineBuilder builder, string path, Encoding encoding)
+    {
+        return WithScripts(builder, new FileSystemScriptProvider(path, encoding));
+    }
+
+    /// <summary>
+    /// Adds all scripts from a folder on the file system, with a custom filter and custom encoding.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="path">The directory path.</param>
+    /// <param name="filter">The filter. Use the static <see cref="Filters"/> class to get some pre-defined filters.</param>
+    /// <param name="encoding">The encoding.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsFromFileSystem(this UpgradeEngineBuilder builder, string path, Func<string, bool> filter, Encoding encoding)
+    {
+        return WithScripts(builder, new FileSystemScriptProvider(path, filter, encoding));
+    }
+
+    /// <summary>
     /// Adds all scripts found as embedded resources in the given assembly.
     /// </summary>
     /// <param name="builder">The builder.</param>
@@ -188,6 +219,35 @@ public static class StandardExtensions
     public static UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this UpgradeEngineBuilder builder, Assembly assembly)
     {
         return WithScripts(builder, new EmbeddedScriptProvider(assembly, s => s.EndsWith(".sql", StringComparison.InvariantCultureIgnoreCase)));
+    }
+
+    /// <summary>
+    /// Adds all scripts found as embedded resources in the given assembly, with custom encoding.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="assembly">The assembly.</param>
+    /// <param name="encoding">The encoding.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this UpgradeEngineBuilder builder, Assembly assembly, Encoding encoding)
+    {
+        return WithScripts(builder, new EmbeddedScriptProvider(assembly, s => s.EndsWith(".sql", StringComparison.InvariantCultureIgnoreCase), encoding));
+    }
+
+    /// <summary>
+    /// Adds all scripts found as embedded resources in the given assembly, with custom encoding and with a custom filter (you'll need to exclude non- .SQL files yourself).
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="assembly">The assembly.</param>
+    /// <param name="filter">The filter. Don't forget to ignore any non- .SQL files.</param>
+    /// <param name="encoding">The encoding.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this UpgradeEngineBuilder builder, Assembly assembly, Func<string, bool> filter, Encoding encoding)
+    {
+        return WithScripts(builder, new EmbeddedScriptProvider(assembly, filter, encoding));
     }
 
     /// <summary>

--- a/src/DbUp/Engine/SqlScript.cs
+++ b/src/DbUp/Engine/SqlScript.cs
@@ -45,13 +45,14 @@ namespace DbUp.Engine
         /// 
         /// </summary>
         /// <param name="path"></param>
+        /// <param name="encoding"></param>
         /// <returns></returns>
-        public static SqlScript FromFile(string path)
+        public static SqlScript FromFile(string path, Encoding encoding)
         {
             using (FileStream fileStream = new FileStream(path, FileMode.Open, FileAccess.Read))
             {
                 var fileName = new FileInfo(path).Name;
-                return FromStream(fileName, fileStream);
+                return FromStream(fileName, fileStream, encoding);
             }
         }
 
@@ -60,10 +61,11 @@ namespace DbUp.Engine
         /// </summary>
         /// <param name="scriptName"></param>
         /// <param name="stream"></param>
+        /// <param name="encoding"></param>
         /// <returns></returns>
-        public static SqlScript FromStream(string scriptName, Stream stream)
+        public static SqlScript FromStream(string scriptName, Stream stream, Encoding encoding)
         {
-            using (var resourceStreamReader = new StreamReader(stream, Encoding.Default, true))
+            using (var resourceStreamReader = new StreamReader(stream, encoding, true))
             {
                 string c = resourceStreamReader.ReadToEnd();
                 return new SqlScript(scriptName, c);

--- a/src/DbUp/ScriptProviders/EmbeddedScriptProvider.cs
+++ b/src/DbUp/ScriptProviders/EmbeddedScriptProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using DbUp.Engine;
 using DbUp.Engine.Transactions;
 
@@ -14,6 +15,7 @@ namespace DbUp.ScriptProviders
     {
         private readonly Assembly assembly;
         private readonly Func<string, bool> filter;
+        private Encoding encoding;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EmbeddedScriptProvider"/> class.
@@ -24,6 +26,20 @@ namespace DbUp.ScriptProviders
         {
             this.assembly = assembly;
             this.filter = filter;
+            this.encoding = Encoding.Default;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmbeddedScriptProvider"/> class.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="filter">The filter.</param>
+        /// <param name="encoding">The encoding.</param>
+        public EmbeddedScriptProvider(Assembly assembly, Func<string, bool> filter, Encoding encoding)
+        {
+            this.assembly = assembly;
+            this.filter = filter;
+            this.encoding = encoding;
         }
 
         /// <summary>
@@ -36,7 +52,7 @@ namespace DbUp.ScriptProviders
                 .GetManifestResourceNames()
                 .Where(filter)
                 .OrderBy(x => x)
-                .Select(s => SqlScript.FromStream(s, assembly.GetManifestResourceStream(s)))
+                .Select(s => SqlScript.FromStream(s, assembly.GetManifestResourceStream(s), encoding))
                 .ToList();
         }
 

--- a/src/DbUp/ScriptProviders/FileSystemScriptProvider.cs
+++ b/src/DbUp/ScriptProviders/FileSystemScriptProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using DbUp.Engine;
 using DbUp.Engine.Transactions;
 
@@ -14,6 +15,7 @@ namespace DbUp.ScriptProviders
     {
         private readonly string directoryPath;
         private readonly Func<string, bool> filter;
+        private readonly Encoding encoding;
 
         ///<summary>
         ///</summary>
@@ -22,6 +24,7 @@ namespace DbUp.ScriptProviders
         {
             this.directoryPath = directoryPath;
             this.filter = null;
+            this.encoding = Encoding.Default;
         }
 
         ///<summary>
@@ -32,6 +35,30 @@ namespace DbUp.ScriptProviders
         {
             this.directoryPath = directoryPath;
             this.filter = filter;
+            this.encoding = Encoding.Default;
+        }
+
+        ///<summary>
+        ///</summary>
+        ///<param name="directoryPath">Path to SQL upgrade scripts</param>
+        ///<param name="encoding">The encoding.</param>
+        public FileSystemScriptProvider(string directoryPath, Encoding encoding)
+        {
+            this.directoryPath = directoryPath;
+            this.filter = null;
+            this.encoding = encoding;
+        }
+
+        ///<summary>
+        ///</summary>
+        ///<param name="directoryPath">Path to SQL upgrade scripts</param>
+        ///<param name="filter">The filter.</param>
+        ///<param name="encoding">The encoding.</param>
+        public FileSystemScriptProvider(string directoryPath, Func<string, bool> filter, Encoding encoding)
+        {
+            this.directoryPath = directoryPath;
+            this.filter = filter;
+            this.encoding = encoding;
         }
 
         /// <summary>
@@ -44,7 +71,7 @@ namespace DbUp.ScriptProviders
             {
                 files = files.Where(filter);
             }
-            return files.Select(SqlScript.FromFile).ToList();
+            return files.Select(x => SqlScript.FromFile(x, encoding)).ToList();
         }
 
 


### PR DESCRIPTION
In our project, we're using sql files with unicode characters. These need to be run against a MySQL database. Turns out, using Encoding.Default when defining the StreamReader (as DbUp does) doesn't correctly do that and the data inserted in the tables is gibberish. Managed to fix the issue by specifying Encoding.UTF8 when defining the StreamReader, but there was no built-in way of doing that with DbUp.
This change aims to add support for specifying custom encoding.