### PR TITLE
Enable loading scripts from multiple assemblies

### DIFF
--- a/src/DbUp/Builder/StandardExtensions.cs
+++ b/src/DbUp/Builder/StandardExtensions.cs
@@ -425,4 +425,59 @@ public static class StandardExtensions
         return builder;
     }
 
+    /// <summary>
+    /// Adds all scripts ending in '.sql' found as embedded resources in the given assemblies, using the default <see cref="Encoding" />.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="assemblies">The assemblies.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this UpgradeEngineBuilder builder, Assembly[] assemblies)
+    {
+        return WithScriptsEmbeddedInAssemblies(builder, assemblies, s => s.EndsWith(".sql", StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    /// <summary>
+    /// Adds all scripts matching the specified filter found as embedded resources in the given assemblies, using the default <see cref="Encoding" />.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="assemblies">The assemblies.</param>
+    /// <param name="filter">The filter. Don't forget to ignore any non- .SQL files.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this UpgradeEngineBuilder builder, Assembly[] assemblies, Func<string, bool> filter)
+    {
+        return WithScriptsEmbeddedInAssemblies(builder, assemblies, filter, Encoding.Default);
+    }
+
+    /// <summary>
+    /// Adds all scripts ending in '.sql' found as embedded resources in the given assemblies, using the specified <see cref="Encoding" />.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="assemblies">The assemblies.</param>
+    /// <param name="encoding">The encoding.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this UpgradeEngineBuilder builder, Assembly[] assemblies, Encoding encoding)
+    {
+        return WithScriptsEmbeddedInAssemblies(builder, assemblies, s => s.EndsWith(".sql", StringComparison.InvariantCultureIgnoreCase), encoding);
+    }
+
+    /// <summary>
+    /// Adds all scripts found as embedded resources in the given assemblies, with a custom filter (you'll need to exclude non- .SQL files yourself).
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="assemblies">The assemblies.</param>
+    /// <param name="filter">The filter. Don't forget to ignore any non- .SQL files.</param>
+    /// <param name="encoding">The encoding.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this UpgradeEngineBuilder builder, Assembly[] assemblies, Func<string, bool> filter, Encoding encoding)
+    {
+        return WithScripts(builder, new EmbeddedScriptsProvider(assemblies, filter, encoding));
+    }
 }

--- a/src/DbUp/DbUp.csproj
+++ b/src/DbUp/DbUp.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Engine\Transactions\TransactionPerScriptStrategy.cs" />
     <Compile Include="Helpers\Filters.cs" />
     <Compile Include="Helpers\NullJournal.cs" />
+    <Compile Include="ScriptProviders\EmbeddedScriptsProvider.cs" />
     <Compile Include="Support\Firebird\FirebirdTableJournal.cs" />
     <Compile Include="Support\MySql\MySqlITableJournal.cs" />
     <Compile Include="Support\Postgresql\PostgresqlTableJournal.cs" />

--- a/src/DbUp/Engine/SqlScript.cs
+++ b/src/DbUp/Engine/SqlScript.cs
@@ -7,6 +7,7 @@ namespace DbUp.Engine
     /// <summary>
     /// Represents a SQL Server script that comes from an embedded resource in an assembly. 
     /// </summary>
+    [System.Diagnostics.DebuggerDisplay("{Name}")]
     public class SqlScript
     {
         private readonly string contents;

--- a/src/DbUp/ScriptProviders/EmbeddedScriptsProvider.cs
+++ b/src/DbUp/ScriptProviders/EmbeddedScriptsProvider.cs
@@ -1,0 +1,52 @@
+namespace DbUp.ScriptProviders
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using DbUp.Engine;
+    using DbUp.Engine.Transactions;
+
+    /// <summary>
+    /// An <see cref="IScriptProvider"/> implementation which retrieves upgrade scripts embedded in assemblies.
+    /// </summary>
+    public sealed class EmbeddedScriptsProvider : IScriptProvider
+    {
+        private readonly Assembly[] assemblies;
+        private readonly Encoding encoding;
+        private readonly Func<string, bool> filter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmbeddedScriptsProvider"/> class.
+        /// </summary>
+        /// <param name="assemblies">The assemblies to search.</param>
+        /// <param name="filter">The filter.</param>
+        /// <param name="encoding">The encoding.</param>
+        public EmbeddedScriptsProvider(Assembly[] assemblies, Func<string, bool> filter, Encoding encoding)
+        {
+            this.assemblies = assemblies;
+            this.filter = filter;
+            this.encoding = encoding;
+        }
+
+        /// <summary>
+        /// Gets all scripts that should be executed.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<SqlScript> GetScripts(IConnectionManager connectionManager)
+        {
+            var sqlScripts = this.assemblies
+                .Select(assembly => new
+                {
+                    Assembly = assembly,
+                    ResourceNames = assembly.GetManifestResourceNames().Where(this.filter).ToArray()
+                })
+                .SelectMany(x => x.ResourceNames.Select(resourceName => SqlScript.FromStream(resourceName, x.Assembly.GetManifestResourceStream(resourceName), this.encoding)))
+                .OrderBy(sqlScript => sqlScript.Name)
+                .ToList();
+
+            return sqlScripts;
+        }
+    }
+}


### PR DESCRIPTION
I've been playing with DbUp in a project but in my scenario I need to manage scripts within multiple assemblies.

I have a service which assembly loads plugins and each of those plugins need their own table schema(s) maintaining.

This change allows me to manage the scripts for each plugin within the plugin project itself rather than the hosting assembly needing to know about any of the database schema for a plugin,