### PR TITLE
Issue-96-When-error-in-script-occurred-DbUp-method-Perform-Upgrade-do…

### DIFF
--- a/src/DbUp/Engine/UpgradeEngine.cs
+++ b/src/DbUp/Engine/UpgradeEngine.cs
@@ -62,6 +62,9 @@ namespace DbUp.Engine
         public DatabaseUpgradeResult PerformUpgrade()
         {
             var executed = new List<SqlScript>();
+
+            string executedScriptName = null;
+
             try
             {
                 using (configuration.ConnectionManager.OperationStarting(configuration.Log, executed))
@@ -80,6 +83,8 @@ namespace DbUp.Engine
 
                     foreach (var script in scriptsToExecute)
                     {
+                        executedScriptName = script.Name;
+
                         configuration.ScriptExecutor.Execute(script, configuration.Variables);
 
                         configuration.Journal.StoreExecutedScript(script);
@@ -93,6 +98,7 @@ namespace DbUp.Engine
             }
             catch (Exception ex)
             {
+                ex.Data.Add("Error occurred in script: ", executedScriptName);
                 configuration.Log.WriteError("Upgrade failed due to an unexpected exception:\r\n{0}", ex.ToString());
                 return new DatabaseUpgradeResult(executed, false, ex);
             }


### PR DESCRIPTION
When i invoke method PerformUpgrade (DbUp.Engine.UpgradeEngine), and i have script with error, DbUp fails and method PerformUpgrade returned DatabaseUpgradeResult which contain Exception, but info about exception does not provide the name of the failed script.