### PR TITLE
Added EnsureDatabase.For

### DIFF
--- a/src/DbUp.Console/Program.cs
+++ b/src/DbUp.Console/Program.cs
@@ -24,7 +24,7 @@ namespace DbUp.Console
                 { "s|server=", "the SQL Server host", s => server = s },
                 { "db|database=", "database to upgrade", d => database = d},
                 { "d|directory=", "directory containing SQL Update files", dir => directory = dir },
-                { "e|ensure", "ensure datbase exists", e => ensure_database = e != null }
+                { "e|ensure", "ensure datbase exists", e => ensure_database = e != null },
                 { "u|user=", "Database username", u => username = u},
                 { "p|password=", "Database password", p => password = p},
                 { "cs|connectionString=", "Full connection string", cs => connectionString = cs},
@@ -59,7 +59,7 @@ namespace DbUp.Console
             DatabaseUpgradeResult result = null;
             if (!mark)
             {
-                EnsureDatabase.For.SqlDatabase(connectionString);
+                if (ensure_database) EnsureDatabase.For.SqlDatabase(connectionString);
                 result = dbup.PerformUpgrade();
             }
             else

--- a/src/DbUp.Console/Program.cs
+++ b/src/DbUp.Console/Program.cs
@@ -18,11 +18,13 @@ namespace DbUp.Console
             var connectionString = "";
 
             bool show_help = false;
+            bool ensure_database = false;
 
             var optionSet = new OptionSet() {
                 { "s|server=", "the SQL Server host", s => server = s },
                 { "db|database=", "database to upgrade", d => database = d},
                 { "d|directory=", "directory containing SQL Update files", dir => directory = dir },
+                { "e|ensure", "ensure datbase exists", e => ensure_database = e != null }
                 { "u|user=", "Database username", u => username = u},
                 { "p|password=", "Database password", p => password = p},
                 { "cs|connectionString=", "Full connection string", cs => connectionString = cs},
@@ -57,6 +59,7 @@ namespace DbUp.Console
             DatabaseUpgradeResult result = null;
             if (!mark)
             {
+                EnsureDatabase.For.SqlDatabase(connectionString);
                 result = dbup.PerformUpgrade();
             }
             else

--- a/src/DbUp.Firebird/FirebirdExtensions.cs
+++ b/src/DbUp.Firebird/FirebirdExtensions.cs
@@ -42,15 +42,4 @@ public static class FirebirdExtensions
         builder.WithPreprocessor(new FirebirdPreprocessor());
         return builder;
     }
-
-    /// <summary>
-    /// Ensures that the database specified in the connection string exists.
-    /// </summary>
-    /// <param name="supported">Fluent helper type.</param>
-    /// <param name="connectionString">The connection string.</param>
-    /// <returns></returns>
-    public static void FirebirdDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString)
-    {
-        throw new NotImplementedException("EnsureDatabase not supported for Firebird databases.");
-    }
 }

--- a/src/DbUp.Firebird/FirebirdExtensions.cs
+++ b/src/DbUp.Firebird/FirebirdExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using DbUp.Builder;
 using System;
+using DbUp;
 using DbUp.Firebird;
 using DbUp.Engine.Transactions;
 using DbUp.Support.SqlServer;
@@ -40,5 +41,16 @@ public static class FirebirdExtensions
         builder.Configure(c => c.Journal = new FirebirdTableJournal(() => c.ConnectionManager, () => c.Log, "schemaversions"));
         builder.WithPreprocessor(new FirebirdPreprocessor());
         return builder;
+    }
+
+    /// <summary>
+    /// Ensures that the database specified in the connection string exists.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <returns></returns>
+    public static void FirebirdDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString)
+    {
+        throw new NotImplementedException("EnsureDatabase not supported for Firebird databases.");
     }
 }

--- a/src/DbUp.MySql/MySqlExtensions.cs
+++ b/src/DbUp.MySql/MySqlExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using DbUp.Builder;
 using System;
+using DbUp;
 using DbUp.MySql;
 using DbUp.Engine.Transactions;
 using DbUp.Support.SqlServer;
@@ -39,5 +40,16 @@ public static class MySqlExtensions
         builder.Configure(c => c.Journal = new MySqlITableJournal(() => c.ConnectionManager, () => c.Log, null, "schemaversions"));
         builder.WithPreprocessor(new MySqlPreprocessor());
         return builder;
+    }
+
+    /// <summary>
+    /// Ensures that the database specified in the connection string exists.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <returns></returns>
+    public static void MySqlDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString)
+    {
+        throw new NotImplementedException("EnsureDatabase not supported for MySql databases.");
     }
 }

--- a/src/DbUp.MySql/MySqlExtensions.cs
+++ b/src/DbUp.MySql/MySqlExtensions.cs
@@ -41,15 +41,4 @@ public static class MySqlExtensions
         builder.WithPreprocessor(new MySqlPreprocessor());
         return builder;
     }
-
-    /// <summary>
-    /// Ensures that the database specified in the connection string exists.
-    /// </summary>
-    /// <param name="supported">Fluent helper type.</param>
-    /// <param name="connectionString">The connection string.</param>
-    /// <returns></returns>
-    public static void MySqlDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString)
-    {
-        throw new NotImplementedException("EnsureDatabase not supported for MySql databases.");
-    }
 }

--- a/src/DbUp.Postgresql/PostgresqlExtensions.cs
+++ b/src/DbUp.Postgresql/PostgresqlExtensions.cs
@@ -1,4 +1,6 @@
-﻿using DbUp.Builder;
+﻿using System;
+using DbUp;
+using DbUp.Builder;
 using DbUp.Postgresql;
 using DbUp.Engine.Transactions;
 using DbUp.Support.SqlServer;
@@ -39,5 +41,16 @@ public static class PostgresqlExtensions
         builder.Configure(c => c.Journal = new PostgresqlTableJournal(() => c.ConnectionManager, () => c.Log, null, "schemaversions"));
         builder.WithPreprocessor(new PostgresqlPreprocessor());
         return builder;
+    }
+
+    /// <summary>
+    /// Ensures that the database specified in the connection string exists.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <returns></returns>
+    public static void PostgresqlDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString)
+    {
+        throw new NotImplementedException("EnsureDatabase not supported for Postgresql databases.");
     }
 }

--- a/src/DbUp.Postgresql/PostgresqlExtensions.cs
+++ b/src/DbUp.Postgresql/PostgresqlExtensions.cs
@@ -42,15 +42,4 @@ public static class PostgresqlExtensions
         builder.WithPreprocessor(new PostgresqlPreprocessor());
         return builder;
     }
-
-    /// <summary>
-    /// Ensures that the database specified in the connection string exists.
-    /// </summary>
-    /// <param name="supported">Fluent helper type.</param>
-    /// <param name="connectionString">The connection string.</param>
-    /// <returns></returns>
-    public static void PostgresqlDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString)
-    {
-        throw new NotImplementedException("EnsureDatabase not supported for Postgresql databases.");
-    }
 }

--- a/src/DbUp.SqlCe/SqlCeExtensions.cs
+++ b/src/DbUp.SqlCe/SqlCeExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data.SqlServerCe;
+using DbUp;
 using DbUp.Builder;
 using DbUp.Engine.Transactions;
 using DbUp.SqlCe;
@@ -50,5 +51,16 @@ public static class SqlCeExtensions
         builder.Configure(c => c.Journal = new SqlTableJournal(()=>connectionManager, ()=>c.Log, null, "SchemaVersions"));
         builder.WithPreprocessor(new SqlCePreprocessor());
         return builder;
+    }
+
+    /// <summary>
+    /// Ensures that the database specified in the connection string exists.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <returns></returns>
+    public static void SqlCeDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString)
+    {
+        throw new NotImplementedException("EnsureDatabase not supported for SQL CE databases.");
     }
 }

--- a/src/DbUp.SqlCe/SqlCeExtensions.cs
+++ b/src/DbUp.SqlCe/SqlCeExtensions.cs
@@ -52,15 +52,4 @@ public static class SqlCeExtensions
         builder.WithPreprocessor(new SqlCePreprocessor());
         return builder;
     }
-
-    /// <summary>
-    /// Ensures that the database specified in the connection string exists.
-    /// </summary>
-    /// <param name="supported">Fluent helper type.</param>
-    /// <param name="connectionString">The connection string.</param>
-    /// <returns></returns>
-    public static void SqlCeDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString)
-    {
-        throw new NotImplementedException("EnsureDatabase not supported for SQL CE databases.");
-    }
 }

--- a/src/DbUp.Sqlite/SqliteExtensions.cs
+++ b/src/DbUp.Sqlite/SqliteExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using DbUp;
 using DbUp.Builder;
 using DbUp.SQLite.Helpers;
 using DbUp.Support.SQLite;
@@ -51,5 +52,16 @@ public static class SQLiteExtensions
             () => c.VariablesEnabled, c.ScriptPreprocessors));
         builder.WithPreprocessor(new SQLitePreprocessor());
         return builder;
+    }
+
+    /// <summary>
+    /// Ensures that the database specified in the connection string exists.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <returns></returns>
+    public static void SQLiteDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString)
+    {
+        throw new NotImplementedException("EnsureDatabase not supported for SQLite databases.");
     }
 }

--- a/src/DbUp.Sqlite/SqliteExtensions.cs
+++ b/src/DbUp.Sqlite/SqliteExtensions.cs
@@ -53,15 +53,4 @@ public static class SQLiteExtensions
         builder.WithPreprocessor(new SQLitePreprocessor());
         return builder;
     }
-
-    /// <summary>
-    /// Ensures that the database specified in the connection string exists.
-    /// </summary>
-    /// <param name="supported">Fluent helper type.</param>
-    /// <param name="connectionString">The connection string.</param>
-    /// <returns></returns>
-    public static void SQLiteDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString)
-    {
-        throw new NotImplementedException("EnsureDatabase not supported for SQLite databases.");
-    }
 }

--- a/src/DbUp.Tests/DbUp.approved.cs
+++ b/src/DbUp.Tests/DbUp.approved.cs
@@ -37,12 +37,20 @@ namespace DbUp
     {
         public static DbUp.Builder.SupportedDatabases To { get; }
     }
+    public class static EnsureDatabase
+    {
+        public static DbUp.SupportedDatabasesForEnsureDatabase For { get; }
+    }
     public class static Filters
     {
         public static System.Func<string, bool> ExcludeScriptNamesInFile(string fileName) { }
         public static System.Func<string, bool> ExcludeScripts(params string[] scriptNames) { }
         public static System.Func<string, bool> OnlyIncludeScriptNamesInFile(string fileName) { }
         public static System.Func<string, bool> OnlyIncludeScripts(params string[] scriptNames) { }
+    }
+    public class SupportedDatabasesForEnsureDatabase
+    {
+        public SupportedDatabasesForEnsureDatabase() { }
     }
 }
 namespace DbUp.Engine
@@ -397,6 +405,8 @@ public class static SqlServerExtensions
     [System.ObsoleteAttribute("Pass connection string instead, then use .WithTransaction() and .WithTransactionP" +
         "erScript() to manage connection behaviour")]
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, System.Func<System.Data.IDbConnection> connectionFactory, string schema) { }
+    public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
+    public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.Engine.Output.IUpgradeLog logger) { }
 }
 public class static StandardExtensions
 {

--- a/src/DbUp/DbUp.csproj
+++ b/src/DbUp/DbUp.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Builder\StandardExtensions.cs" />
     <Compile Include="Builder\UpgradeConfiguration.cs" />
     <Compile Include="Builder\UpgradeEngineBuilder.cs" />
+    <Compile Include="EnsureDatabase.cs" />
     <Compile Include="DeployChanges.cs" />
     <Compile Include="Engine\DelegateDisposable.cs" />
     <Compile Include="Engine\Output\SqlContextUpgradeLog.cs" />
@@ -73,6 +74,7 @@
     <Compile Include="Helpers\Filters.cs" />
     <Compile Include="Helpers\NullJournal.cs" />
     <Compile Include="ScriptProviders\EmbeddedScriptsProvider.cs" />
+    <Compile Include="SupportedDatabasesForEnsureDatabase.cs" />
     <Compile Include="Support\Firebird\FirebirdTableJournal.cs" />
     <Compile Include="Support\MySql\MySqlITableJournal.cs" />
     <Compile Include="Support\Postgresql\PostgresqlTableJournal.cs" />

--- a/src/DbUp/EnsureDatabase.cs
+++ b/src/DbUp/EnsureDatabase.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace DbUp
+{
+    /// <summary>
+    /// A fluent interface for creating the target database.
+    /// </summary>
+    public static class EnsureDatabase
+    {
+        private static readonly SupportedDatabasesForEnsureDatabase Instance = new SupportedDatabasesForEnsureDatabase();
+
+        /// <summary>
+        /// Returns the databases supported by DbUp's EnsureDatabase feature.
+        /// </summary>
+        public static SupportedDatabasesForEnsureDatabase For
+        {
+            get { return Instance; }
+        }
+    }
+}

--- a/src/DbUp/Support/SqlServer/SqlServerExtensions.cs
+++ b/src/DbUp/Support/SqlServer/SqlServerExtensions.cs
@@ -132,20 +132,25 @@ public static class SqlServerExtensions
 
         if (logger == null) throw new ArgumentNullException("logger");
 
-        var connectionStringBuilder = new SqlConnectionStringBuilder(connectionString);
+        var masterConnectionStringBuilder = new SqlConnectionStringBuilder(connectionString);
 
-        var databaseName = connectionStringBuilder.InitialCatalog;
+        var databaseName = masterConnectionStringBuilder.InitialCatalog;
 
         if (string.IsNullOrEmpty(databaseName) || databaseName.Trim() == string.Empty)
         {
             throw new InvalidOperationException("The connection string does not specify a database name.");
         }
 
-        connectionStringBuilder.InitialCatalog = "master";
+        masterConnectionStringBuilder.InitialCatalog = "master";
 
-        logger.WriteInformation("Master ConnectionString => {0}", connectionStringBuilder.ToString());
+        var logMasterConnectionStringBuilder = new SqlConnectionStringBuilder(masterConnectionStringBuilder.ConnectionString)
+        {
+            Password = String.Empty.PadRight(masterConnectionStringBuilder.Password.Length,'*')
+        };
+        
+        logger.WriteInformation("Master ConnectionString => {0}", logMasterConnectionStringBuilder.ConnectionString);
 
-        using (var connection = new SqlConnection(connectionStringBuilder.ConnectionString))
+        using (var connection = new SqlConnection(masterConnectionStringBuilder.ConnectionString))
         {
             connection.Open();
             

--- a/src/DbUp/Support/SqlServer/SqlServerExtensions.cs
+++ b/src/DbUp/Support/SqlServer/SqlServerExtensions.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Text;
 using DbUp;
 using DbUp.Builder;
+using DbUp.Engine.Output;
 using DbUp.Engine.Transactions;
 using DbUp.Support.SqlServer;
 
@@ -110,10 +111,26 @@ public static class SqlServerExtensions
     /// <returns></returns>
     public static void SqlDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString)
     {
+        SqlDatabase(supported, connectionString, new ConsoleUpgradeLog());
+    }
+
+    /// <summary>
+    /// Ensures that the database specified in the connection string exists.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="logger">The <see cref="DbUp.Engine.Output.IUpgradeLog"/> used to record actions.</param>
+    /// <returns></returns>
+    public static void SqlDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString, IUpgradeLog logger)
+    {
+        if (supported == null) throw new ArgumentNullException("supported");
+        
         if (string.IsNullOrEmpty(connectionString) || connectionString.Trim() == string.Empty)
         {
             throw new ArgumentNullException("connectionString");
         }
+
+        if (logger == null) throw new ArgumentNullException("logger");
 
         var connectionStringBuilder = new SqlConnectionStringBuilder(connectionString);
 
@@ -126,8 +143,7 @@ public static class SqlServerExtensions
 
         connectionStringBuilder.InitialCatalog = "master";
 
-        // TODO: Where to log output from this method? There is no Log context at this point.
-        Debug.WriteLine("Master ConnectionString => {0}", connectionStringBuilder.ToString());
+        logger.WriteInformation("Master ConnectionString => {0}", connectionStringBuilder.ToString());
 
         using (var connection = new SqlConnection(connectionStringBuilder.ConnectionString))
         {
@@ -168,8 +184,7 @@ public static class SqlServerExtensions
 
             }
 
-            // TODO: Where to log output from this method? There is no Log context at this point.
-            Console.WriteLine(@"Created database {0}", databaseName);
+            logger.WriteInformation(@"Created database {0}", databaseName);
         }
     }
 

--- a/src/DbUp/Support/SqlServer/SqlServerExtensions.cs
+++ b/src/DbUp/Support/SqlServer/SqlServerExtensions.cs
@@ -1,5 +1,9 @@
 ﻿using System;
 using System.Data;
+using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Text;
+using DbUp;
 using DbUp.Builder;
 using DbUp.Engine.Transactions;
 using DbUp.Support.SqlServer;
@@ -97,4 +101,77 @@ public static class SqlServerExtensions
         builder.Configure(c => c.Journal = new SqlTableJournal(()=>c.ConnectionManager, ()=>c.Log, schema, table));
         return builder;
     }
+
+    /// <summary>
+    /// Ensures that the database specified in the connection string exists.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <returns></returns>
+    public static void SqlDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString)
+    {
+        if (string.IsNullOrEmpty(connectionString) || connectionString.Trim() == string.Empty)
+        {
+            throw new ArgumentNullException("connectionString");
+        }
+
+        var connectionStringBuilder = new SqlConnectionStringBuilder(connectionString);
+
+        var databaseName = connectionStringBuilder.InitialCatalog;
+
+        if (string.IsNullOrEmpty(databaseName) || databaseName.Trim() == string.Empty)
+        {
+            throw new InvalidOperationException("The connection string does not specify a database name.");
+        }
+
+        connectionStringBuilder.InitialCatalog = "master";
+
+        // TODO: Where to log output from this method? There is no Log context at this point.
+        Debug.WriteLine("Master ConnectionString => {0}", connectionStringBuilder.ToString());
+
+        using (var connection = new SqlConnection(connectionStringBuilder.ConnectionString))
+        {
+            connection.Open();
+            
+            var sqlCommandText = string.Format
+                (
+                    @"select case when db_id('{0}') is not null then 1 else 0 end;",
+                    databaseName
+                );
+
+
+            // check to see if the database already exists..
+            using (var command = new SqlCommand(sqlCommandText, connection)
+            {
+                CommandType = CommandType.Text
+            })
+            {
+                var results = (int) command.ExecuteScalar();
+
+                // if the database exists, we're done here...
+                if (results == 1) return;
+            }
+
+            sqlCommandText = string.Format
+                    (
+                        @"create database [{0}];",
+                        databaseName
+                    );
+
+            // Create the database...
+            using (var command = new SqlCommand(sqlCommandText, connection)
+            {
+                CommandType = CommandType.Text
+            })
+            {
+                command.ExecuteNonQuery();
+
+            }
+
+            // TODO: Where to log output from this method? There is no Log context at this point.
+            Console.WriteLine(@"Created database {0}", databaseName);
+        }
+    }
+
+
 }

--- a/src/DbUp/SupportedDatabasesForEnsureDatabase.cs
+++ b/src/DbUp/SupportedDatabasesForEnsureDatabase.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace DbUp
+{
+    /// <summary>
+    /// Add extension methods to this type if you plan to add support for EnsureDatabase for additional databases.
+    /// </summary>
+    public class SupportedDatabasesForEnsureDatabase
+    {
+    }
+}


### PR DESCRIPTION
# EnsureDatabase.For #

Issue **#74 Create Db if it doesn't exist**

This new DbUp method ensures the existence of the database that is going to be upgraded. If the database does not exist, it is created. The `CREATE DATABASE` command is executed with default values for all options.

## Changes ##

1. Added a new static class `EnsureDatabase` with a property, `EnsureDatabase.For`, for use semantics similar to `DeployChanges.To`. However, the type of `EnsureDatabase.For` is a new class, `SupportedDatabasesForEnsureDatabase` to disambiguate the extension classes. 
2. Added extension methods for all supported databases, but only implemented the SQL Server extension method. All other extensions methods throw `System.NotImplementedException`.

## Notes ##
1. The argument connectionString is the same connection string used with the Builder for the target database. The extension method works out the connection string for `master`.
2. The return type of the extension method is void. If the database engine throws an exception when creating the database, that exception is _**not**_ caught.

## Example ##
```
EnsureDatabase.For.SqlDatabase(connectionString);
```
## Open Issues ##
It seems like `EnsureDatabase.For` should let the world know what it is doing. For this reason, there are two TODO: items in the SQL Server extension method that highlight code that may need to be changed. The challenge is that we are not in the Builder, so we have no logging context.

* `SqlServerExtensions.cs`, line 129-130. There is a TODO and a `Debug.WriteLine` that displays the master database connection string. This could probably be removed, but seemed like a good idea during debugging.
* `SqlServerExtensions.cs`, line 171-172. There is a TODO and a `ConsoleWriteLine` where the extension method announces that it created the database. This seems like a good idea. However,  `Console.Writeline()` seems too invariant, but the lack of a logging context doesn't leave to many (easy) options.
