### PR TITLE
Script folder recursion

### DIFF
--- a/src/DbUp.Tests/DbUp.approved.cs
+++ b/src/DbUp.Tests/DbUp.approved.cs
@@ -263,9 +263,13 @@ namespace DbUp.ScriptProviders
     public class FileSystemScriptProvider : DbUp.Engine.IScriptProvider
     {
         public FileSystemScriptProvider(string directoryPath) { }
+        public FileSystemScriptProvider(string directoryPath, bool recursive) { }
         public FileSystemScriptProvider(string directoryPath, System.Func<string, bool> filter) { }
+        public FileSystemScriptProvider(string directoryPath, System.Func<string, bool> filter, bool recursive) { }
         public FileSystemScriptProvider(string directoryPath, System.Text.Encoding encoding) { }
+        public FileSystemScriptProvider(string directoryPath, System.Text.Encoding encoding, bool recursive) { }
         public FileSystemScriptProvider(string directoryPath, System.Func<string, bool> filter, System.Text.Encoding encoding) { }
+        public FileSystemScriptProvider(string directoryPath, System.Func<string, bool> filter, System.Text.Encoding encoding, bool recursive) { }
         public System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> GetScripts(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
     }
     public sealed class StaticScriptProvider : DbUp.Engine.IScriptProvider


### PR DESCRIPTION
Pull Request for issue #124.

This Pull Request does _not_ contain any breaking changes to the public API. However, it _**does**_ contain a _**BREAKING CHANGE**_ for the script names stored in the DbUp journal table.

In order to support folder recursion, the `SqlScript.Name` property must contain the path to the script, not just the file name. This changes the script name that is stored in the journal table. So, using this version of DbUp to update an existing database where scripts are source from the file system will make a mess unless the file-based script names in the journal table are first updated to reflect the new script name which includes the relative path from the root script folder.

It seems like this ought to be mentioned in `journaling.md`, but I wasn't quite sure how to introduce it.
