### PR TITLE
Do not substitute variables in comments

### DIFF
--- a/src/DbUp.Tests/Support/SqlServer/SqlScriptExecutorTests.cs
+++ b/src/DbUp.Tests/Support/SqlServer/SqlScriptExecutorTests.cs
@@ -44,12 +44,123 @@ namespace DbUp.Tests.Support.SqlServer
             dbConnection.CreateCommand().Returns(command);
             var executor = new SqlScriptExecutor(() => new TestConnectionManager(dbConnection, true), () => new ConsoleUpgradeLog(), null, () => true, null);
 
-            executor.Execute(new SqlScript("Test", "create $foo$.Table"), new Dictionary<string, string>{{"foo", "bar"}});
+            executor.Execute(new SqlScript("Test", "create $foo$.Table"), new Dictionary<string, string> { { "foo", "bar" } });
 
             command.Received().ExecuteNonQuery();
             Assert.AreEqual("create bar.Table", command.CommandText);
         }
-        
+
+        [Test]
+        public void uses_variable_subtitute_preprocessor_when_running_scripts_with_single_line_comment()
+        {
+            string oneLineComment = @"--from excel $A$6
+                                  create $foo$.Table";
+            string oneLineCommentResult = @"--from excel $A$6
+                                  create bar.Table";
+            var dbConnection = Substitute.For<IDbConnection>();
+            var command = Substitute.For<IDbCommand>();
+            dbConnection.CreateCommand().Returns(command);
+            var executor = new SqlScriptExecutor(() => new TestConnectionManager(dbConnection, true), () => new ConsoleUpgradeLog(), null, () => true, null);
+
+            executor.Execute(new SqlScript("Test", oneLineComment), new Dictionary<string, string> { { "foo", "bar" } });
+
+            command.Received().ExecuteNonQuery();
+            Assert.AreEqual(oneLineCommentResult, command.CommandText);
+        }
+
+        [Test]
+        public void uses_variable_subtitute_preprocessor_when_running_scripts_with_one_line_comment()
+        {
+            string oneLineComment = @"/* from excel $A$6 */
+                                  create $foo$.Table";
+            string oneLineCommentResult = @"/* from excel $A$6 */
+                                  create bar.Table";
+            var dbConnection = Substitute.For<IDbConnection>();
+            var command = Substitute.For<IDbCommand>();
+            dbConnection.CreateCommand().Returns(command);
+            var executor = new SqlScriptExecutor(() => new TestConnectionManager(dbConnection, true), () => new ConsoleUpgradeLog(), null, () => true, null);
+
+            executor.Execute(new SqlScript("Test", oneLineComment), new Dictionary<string, string> { { "foo", "bar" } });
+
+            command.Received().ExecuteNonQuery();
+            Assert.AreEqual(oneLineCommentResult, command.CommandText);
+        }
+
+        [Test]
+        public void uses_variable_subtitute_preprocessor_when_running_scripts_with_multi_line_comment()
+        {
+            string multiLineComment = @"/* 
+                                        some comment
+                                        from excel $A$6 
+                                        some comment
+                                      */
+                                  create $foo$.Table";
+            string multiLineCommentResult = @"/* 
+                                        some comment
+                                        from excel $A$6 
+                                        some comment
+                                      */
+                                  create bar.Table"; var dbConnection = Substitute.For<IDbConnection>();
+            var command = Substitute.For<IDbCommand>();
+            dbConnection.CreateCommand().Returns(command);
+            var executor = new SqlScriptExecutor(() => new TestConnectionManager(dbConnection, true), () => new ConsoleUpgradeLog(), null, () => true, null);
+
+            executor.Execute(new SqlScript("Test", multiLineComment), new Dictionary<string, string> { { "foo", "bar" } });
+
+            command.Received().ExecuteNonQuery();
+            Assert.AreEqual(multiLineCommentResult, command.CommandText);
+        }
+
+        [Test]
+        public void uses_variable_subtitute_preprocessor_when_running_scripts_with_nested_single_line_comment()
+        {
+            string multiLineComment = @"/* 
+                                        some comment
+                                        --from excel $A$6 
+                                        some comment
+                                      */
+                                  create $foo$.Table";
+            string multiLineCommentResult = @"/* 
+                                        some comment
+                                        --from excel $A$6 
+                                        some comment
+                                      */
+                                  create bar.Table"; var dbConnection = Substitute.For<IDbConnection>();
+            var command = Substitute.For<IDbCommand>();
+            dbConnection.CreateCommand().Returns(command);
+            var executor = new SqlScriptExecutor(() => new TestConnectionManager(dbConnection, true), () => new ConsoleUpgradeLog(), null, () => true, null);
+
+            executor.Execute(new SqlScript("Test", multiLineComment), new Dictionary<string, string> { { "foo", "bar" } });
+
+            command.Received().ExecuteNonQuery();
+            Assert.AreEqual(multiLineCommentResult, command.CommandText);
+        }
+
+        [Test]
+        public void uses_variable_subtitute_preprocessor_when_running_scripts_with_nested_comment()
+        {
+            string multiLineComment = @"/* 
+                                        some comment
+                                        /* from excel $A$6 */
+                                        some comment
+                                      */
+                                  create $foo$.Table";
+            string multiLineCommentResult = @"/* 
+                                        some comment
+                                        /* from excel $A$6 */
+                                        some comment
+                                      */
+                                  create bar.Table"; var dbConnection = Substitute.For<IDbConnection>();
+            var command = Substitute.For<IDbCommand>();
+            dbConnection.CreateCommand().Returns(command);
+            var executor = new SqlScriptExecutor(() => new TestConnectionManager(dbConnection, true), () => new ConsoleUpgradeLog(), null, () => true, null);
+
+            executor.Execute(new SqlScript("Test", multiLineComment), new Dictionary<string, string> { { "foo", "bar" } });
+
+            command.Received().ExecuteNonQuery();
+            Assert.AreEqual(multiLineCommentResult, command.CommandText);
+        }
+
         [Test]
         public void does_not_use_variable_subtitute_preprocessor_when_setting_false()
         {

--- a/src/DbUp/Engine/Preprocessors/VariableSubstitutionPreprocessor.cs
+++ b/src/DbUp/Engine/Preprocessors/VariableSubstitutionPreprocessor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Globalization;
 using System.Text.RegularExpressions;
 
@@ -28,15 +29,47 @@ namespace DbUp.Engine.Preprocessors
         /// <param name="contents"></param>
         public string Process(string contents)
         {
-            return tokenRegex.Replace(contents, match => ReplaceToken(match, variables));
+            Regex regexObj = new Regex(@"/\*(?>(?:(?!\*/|/\*).)*)(?>(?:/\*(?>(?:(?!\*/|/\*).)*)\*/(?>(?:(?!\*/|/\*).)*))*).*?\*/|--.*?\r?[\n]", RegexOptions.Singleline);
+            Match commentMatch = regexObj.Match(contents);
+
+            return tokenRegex.Replace(contents, match => ReplaceToken(match, variables, commentMatch));
         }
 
-        private static string ReplaceToken(Match match, IDictionary<string, string> variables)
+        private static bool IsInComment(Match commentMatch, Match variableMatch)
+        {
+            Match m = commentMatch;
+            while (m.Success)
+            {
+                if (variableMatch.Index >= m.Index && variableMatch.Index <= m.Index + m.Length)
+                {
+                    return true;
+                }
+
+                m = m.NextMatch();
+            }
+            return false;
+        }
+
+        private static string ReplaceToken(Match match, IDictionary<string, string> variables, Match commentMatch)
         {
             var variableName = match.Groups["variableName"].Value;
-            if (!variables.ContainsKey(variableName))
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Variable {0} has no value defined", variableName));
-            return variables[variableName];
+            string replaceValue;
+
+            if (!variables.TryGetValue(variableName, out replaceValue))
+            {
+                if (!IsInComment(commentMatch, match))
+                {
+                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Variable {0} has no value defined", variableName));
+                }
+                else
+                {
+                    return match.Value;
+                }
+            }
+            else
+            {
+                return replaceValue;
+            }
         }
     }
 }


### PR DESCRIPTION
Modify VariableSubstitutionPreprocessor class if it does not find a variable in variables dictionary then first check if the variable is in a comment then returns the old value if not in comment then throw exception.

Issue: https://github.com/DbUp/DbUp/issues/140
Forum: https://groups.google.com/forum/#!topic/dbup-discuss/1VQVPLtMgik