### PR TITLE
New version folders script provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DbUp is a .NET library that helps you to deploy changes to SQL Server databases. It tracks which SQL scripts have been run already, and runs the change scripts that are needed to get your database up to date.
 
 [![Join the chat at https://gitter.im/DbUp/DbUp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/DbUp/DbUp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build status](https://ci.appveyor.com/api/projects/status/vm3lg8kk1pxn64pj/branch/master?svg=true)](https://ci.appveyor.com/project/rintje/dbup/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/yv5uccqr5ei8dxbj/branch/master?svg=true)](https://ci.appveyor.com/project/rintje/dbup/branch/master)
 
 |                  | Stable | Prerelease |
 | :--:             |  :--:  |    :--:    |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DbUp is a .NET library that helps you to deploy changes to SQL Server databases. It tracks which SQL scripts have been run already, and runs the change scripts that are needed to get your database up to date.
 
 [![Join the chat at https://gitter.im/DbUp/DbUp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/DbUp/DbUp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build status](https://ci.appveyor.com/api/projects/status/vm3lg8kk1pxn64pj/branch/master?svg=true)](https://ci.appveyor.com/project/DbUp/dbup/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/vm3lg8kk1pxn64pj/branch/master?svg=true)](https://ci.appveyor.com/project/rintje/dbup/branch/master)
 
 |                  | Stable | Prerelease |
 | :--:             |  :--:  |    :--:    |

--- a/src/DbUp.Tests/DbUp.Tests.csproj
+++ b/src/DbUp.Tests/DbUp.Tests.csproj
@@ -104,6 +104,7 @@
     <Compile Include="DeployChangesBuilderTests.cs" />
     <Compile Include="Helpers\FilterFactoryTests.cs" />
     <Compile Include="Helpers\NullJournalTests.cs" />
+    <Compile Include="ScriptProvider\VersionFoldersScriptProviderTests.cs" />
     <Compile Include="TestInfrastructure\Scrubbers.cs" />
     <Compile Include="Support\MySql\MySqlConnectionManagerTests.cs" />
     <Compile Include="Support\MySql\MySqlSupportTests.cs" />

--- a/src/DbUp.Tests/DbUp.approved.cs
+++ b/src/DbUp.Tests/DbUp.approved.cs
@@ -273,6 +273,15 @@ namespace DbUp.ScriptProviders
         public StaticScriptProvider(System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> scripts) { }
         public System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> GetScripts(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
     }
+    public class VersionFoldersScriptProvider : DbUp.Engine.IScriptProvider
+    {
+        public VersionFoldersScriptProvider(string directoryPath) { }
+        public VersionFoldersScriptProvider(string directoryPath, string targetVersion) { }
+        public VersionFoldersScriptProvider(string directoryPath, System.Text.Encoding encoding, string targetVersion) { }
+        public VersionFoldersScriptProvider(string directoryPath, System.Func<string, bool> filter, string targetVersion) { }
+        public VersionFoldersScriptProvider(string directoryPath, System.Text.Encoding encoding, System.Func<string, bool> filter, string targetVersion) { }
+        public System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> GetScripts(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
+    }
 }
 namespace DbUp.Support.Firebird
 {
@@ -438,6 +447,11 @@ public class static StandardExtensions
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Func<string, bool> filter) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Text.Encoding encoding) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Func<string, bool> filter, System.Text.Encoding encoding) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromVersionFolders(this DbUp.Builder.UpgradeEngineBuilder builder, string path) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromVersionFolders(this DbUp.Builder.UpgradeEngineBuilder builder, string path, string targetVersion) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromVersionFolders(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Text.Encoding encoding, string targetVersion) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromVersionFolders(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Func<string, bool> filter, string targetVersion) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromVersionFolders(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Text.Encoding encoding, System.Func<string, bool> filter, string targetVersion) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithTransaction(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithTransactionPerScript(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithVariable(this DbUp.Builder.UpgradeEngineBuilder builder, string variableName, string value) { }

--- a/src/DbUp.Tests/ScriptProvider/VersionFoldersScriptProviderTests.cs
+++ b/src/DbUp.Tests/ScriptProvider/VersionFoldersScriptProviderTests.cs
@@ -1,0 +1,530 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using DbUp.Engine;
+using DbUp.Engine.Transactions;
+using DbUp.ScriptProviders;
+using DbUp.Tests.TestInfrastructure;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace DbUp.Tests.ScriptProvider
+{
+    public class VersionFoldersScriptProviderTests
+    {
+        [TestFixture]
+        public class when_returning_scripts_from_version_folders : SpecificationFor<VersionFoldersScriptProvider>
+        {
+            private string testPath;
+            private IEnumerable<SqlScript> filesToExecute;
+
+            public override VersionFoldersScriptProvider Given()
+            {
+                CreateTestFiles();
+
+
+                return new VersionFoldersScriptProvider(testPath);
+            }
+
+            [TearDown]
+            public void CleanUp()
+            {
+                Directory.Delete(testPath, true);
+            }
+
+            private void CreateTestFiles()
+            {
+                var assembly = Assembly.GetExecutingAssembly();
+                var directory = new FileInfo(assembly.Location).DirectoryName;
+
+                testPath = Path.Combine(directory, "sqlfiles");
+                Directory.CreateDirectory(testPath);
+
+                var subpath1 = Path.Combine(testPath, "20150101-apple");
+                Directory.CreateDirectory(subpath1);
+
+                var subpath2 = Path.Combine(testPath, "20150110-banana");
+                Directory.CreateDirectory(subpath2);
+
+                var index = 0;
+                foreach (var scriptName in assembly.GetManifestResourceNames().Where(f => f.Contains(".sql")))
+                {
+                    using (var stream = assembly.GetManifestResourceStream(scriptName))
+                    {
+                        // split files in two separate version directories
+                        var destPath = index < 1 ? subpath1 : subpath2;
+
+                        var filePath = Path.Combine(destPath, scriptName);
+                        using (var writer = new FileStream(filePath, FileMode.CreateNew))
+                        {
+
+                            stream.CopyTo(writer);
+                            writer.Flush();
+                            writer.Close();
+                        }
+                        stream.Close();
+                    }
+
+                    index++;
+                }
+            }
+
+            public override void When()
+            {
+                filesToExecute = Subject.GetScripts(Arg.Any<IConnectionManager>());
+            }
+
+            [Then]
+            public void it_should_return_all_sql_files()
+            {
+                Assert.AreEqual(5, filesToExecute.Count());
+            }
+
+            [Then]
+            public void the_file_should_contain_content()
+            {
+                foreach (var sqlScript in filesToExecute)
+                {
+                    Assert.IsTrue(sqlScript.Contents.Length > 0);
+                }
+            }
+
+            [Then]
+            public void the_files_should_have_correct_folder_prefix()
+            {
+                Assert.That(filesToExecute.ElementAt(0).Name.EndsWith(@"20150101-apple\DbUp.Tests.TestScripts.Script20110301_1_Test1.sql"));
+                Assert.That(filesToExecute.ElementAt(1).Name.EndsWith(@"20150110-banana\DbUp.Tests.TestScripts.Script20110301_2_Test2.sql"));
+                Assert.That(filesToExecute.ElementAt(2).Name.EndsWith(@"20150110-banana\DbUp.Tests.TestScripts.Script20110302_1_Test3.sql"));
+                Assert.That(filesToExecute.ElementAt(3).Name.EndsWith(@"20150110-banana\DbUp.Tests.TestScripts.Script20130525_1_Test5.sql"));
+                Assert.That(filesToExecute.ElementAt(4).Name.EndsWith(@"20150110-banana\DbUp.Tests.TestScripts.Script20130525_2_Test5.sql"));
+            }
+
+            [Then]
+            public void the_files_should_be_correctly_ordered()
+            {
+                Assert.That(filesToExecute.First().Name.EndsWith(@"20150101-apple\DbUp.Tests.TestScripts.Script20110301_1_Test1.sql"));
+                Assert.That(filesToExecute.Last().Name.EndsWith(@"20150110-banana\DbUp.Tests.TestScripts.Script20130525_2_Test5.sql"));
+            }
+
+            [Then]
+            public void encoding_reader_is_correct()
+            {
+                // ANSI encoding
+                Assert.AreEqual("é", filesToExecute.Single(f => f.Name.EndsWith("Script20130525_1_Test5.sql")).Contents);
+
+                // UTF8 encoding
+                Assert.AreEqual("é", filesToExecute.Single(f => f.Name.EndsWith("Script20130525_2_Test5.sql")).Contents);
+            }
+        }
+
+        [TestFixture]
+        public class when_returning_scripts_from_version_folders_and_using_a_target_version : SpecificationFor<VersionFoldersScriptProvider>
+        {
+            private string testPath;
+            private Func<string, bool> filter = null;
+            private string targetVersion;
+            private IEnumerable<SqlScript> filesToExecute;
+
+            public override VersionFoldersScriptProvider Given()
+            {
+                CreateTestFiles();
+
+                targetVersion = "20150101-apple";
+
+                return new VersionFoldersScriptProvider(testPath, filter, targetVersion);
+            }
+
+            [TearDown]
+            public void CleanUp()
+            {
+                Directory.Delete(testPath, true);
+            }
+
+            private void CreateTestFiles()
+            {
+                var assembly = Assembly.GetExecutingAssembly();
+                var directory = new FileInfo(assembly.Location).DirectoryName;
+
+                testPath = Path.Combine(directory, "sqlfiles");
+                Directory.CreateDirectory(testPath);
+
+                var subpath1 = Path.Combine(testPath, "20150101-apple");
+                Directory.CreateDirectory(subpath1);
+
+                var subpath2 = Path.Combine(testPath, "20150110-banana");
+                Directory.CreateDirectory(subpath2);
+
+                var index = 0;
+                foreach (var scriptName in assembly.GetManifestResourceNames().Where(f => f.Contains(".sql")))
+                {
+                    using (var stream = assembly.GetManifestResourceStream(scriptName))
+                    {
+                        // split files in two separate version directories
+                        var destPath = index < 1 ? subpath1 : subpath2;
+
+                        var filePath = Path.Combine(destPath, scriptName);
+                        using (var writer = new FileStream(filePath, FileMode.CreateNew))
+                        {
+
+                            stream.CopyTo(writer);
+                            writer.Flush();
+                            writer.Close();
+                        }
+                        stream.Close();
+                    }
+
+                    index++;
+                }
+            }
+
+            public override void When()
+            {
+                filesToExecute = Subject.GetScripts(Arg.Any<IConnectionManager>());
+            }
+
+            [Then]
+            public void the_target_version_should_have_been_applied()
+            {
+                Assert.That(filesToExecute.Count() == 1);
+                Assert.That(filesToExecute.ElementAt(0).Name.EndsWith(@"20150101-apple\DbUp.Tests.TestScripts.Script20110301_1_Test1.sql"));
+            }
+        }
+
+        [TestFixture]
+        public class when_returning_scripts_from_version_folders_and_using_a_target_version2 : SpecificationFor<VersionFoldersScriptProvider>
+        {
+            private string testPath = null;
+            private Func<string, bool> filter = null;
+            private string targetVersion;
+            private IEnumerable<SqlScript> filesToExecute;
+
+            public override VersionFoldersScriptProvider Given()
+            {
+                CreateTestFiles();
+
+                targetVersion = "3.6.0.1";
+
+                return new VersionFoldersScriptProvider(testPath, filter, targetVersion);
+            }
+
+            [TearDown]
+            public void CleanUp()
+            {
+                Directory.Delete(testPath, true);
+            }
+
+            private void CreateTestFiles()
+            {
+                var assembly = Assembly.GetExecutingAssembly();
+                var directory = new FileInfo(assembly.Location).DirectoryName;
+
+                testPath = Path.Combine(directory, "sqlfiles");
+                Directory.CreateDirectory(testPath);
+
+                var subpath1 = Path.Combine(testPath, "3 4");
+                Directory.CreateDirectory(subpath1);
+
+                var subpath2 = Path.Combine(testPath, "3-5_0~2");
+                Directory.CreateDirectory(subpath2);
+
+                var subpath3 = Path.Combine(testPath, "3,6.0");
+                Directory.CreateDirectory(subpath3);
+
+                var subpath4 = Path.Combine(testPath, "3.6.0.1");
+                Directory.CreateDirectory(subpath4);
+
+                var subpath5 = Path.Combine(testPath, "3.7");
+                Directory.CreateDirectory(subpath5);
+
+                var paths = new List<string>() { subpath1, subpath2, subpath3, subpath4, subpath5 };
+
+                var index = 0;
+                foreach (var scriptName in assembly.GetManifestResourceNames().Where(f => f.Contains(".sql")).OrderBy(f => f))
+                {
+                    using (var stream = assembly.GetManifestResourceStream(scriptName))
+                    {
+                        // split files in two separate version directories
+                        var destPath = paths[ index ];
+
+                        var filePath = Path.Combine(destPath, scriptName);
+                        using (var writer = new FileStream(filePath, FileMode.CreateNew))
+                        {
+
+                            stream.CopyTo(writer);
+                            writer.Flush();
+                            writer.Close();
+                        }
+                        stream.Close();
+                    }
+
+                    index++;
+                }
+            }
+
+            public override void When()
+            {
+                filesToExecute = Subject.GetScripts(Arg.Any<IConnectionManager>());
+            }
+
+            [Then]
+            public void the_target_version_should_have_been_applied_precisely()
+            {
+                Assert.That(filesToExecute.Count() == 4);
+                Assert.That(filesToExecute.ElementAt(0).Name.EndsWith(@"3 4\DbUp.Tests.TestScripts.Script20110301_1_Test1.sql"));
+                Assert.That(filesToExecute.ElementAt(1).Name.EndsWith(@"3,6.0\DbUp.Tests.TestScripts.Script20110302_1_Test3.sql"));
+                Assert.That(filesToExecute.ElementAt(2).Name.EndsWith(@"3-5_0~2\DbUp.Tests.TestScripts.Script20110301_2_Test2.sql"));
+                Assert.That(filesToExecute.ElementAt(3).Name.EndsWith(@"3.6.0.1\DbUp.Tests.TestScripts.Script20130525_1_Test5.sql"));
+            }
+        }
+
+        [TestFixture]
+        public class when_returning_scripts_from_version_folders_and_using_a_filter_and_target_version : SpecificationFor<VersionFoldersScriptProvider>
+        {
+            private string testPath;
+            private bool _FilterExecuted = false;
+            private Func<string, bool> filter;
+
+            private string targetVersion;
+            private IEnumerable<SqlScript> filesToExecute;
+
+            public override VersionFoldersScriptProvider Given()
+            {
+                CreateTestFiles();
+
+                // Given a filter is provided..
+                filter = (a) =>
+                {
+                    _FilterExecuted = true;
+                    return
+                        !a.EndsWith(@"20150101-apple\DbUp.Tests.TestScripts.Script20110301_2_Test2.sql") &&
+                        !a.Equals("folder_containing_invalid_scripts");
+                };
+
+                targetVersion = "20150101-apple";
+
+                return new VersionFoldersScriptProvider(testPath, filter, targetVersion);
+            }
+
+            [TearDown]
+            public void CleanUp()
+            {
+                Directory.Delete(testPath, true);
+            }
+
+            private void CreateTestFiles()
+            {
+                var assembly = Assembly.GetExecutingAssembly();
+                var directory = new FileInfo(assembly.Location).DirectoryName;
+
+                testPath = Path.Combine(directory, "sqlfiles");
+                Directory.CreateDirectory(testPath);
+
+                var subpath1 = Path.Combine(testPath, "20150101-apple");
+                Directory.CreateDirectory(subpath1);
+
+                var subpath2 = Path.Combine(testPath, "20150110-banana");
+                Directory.CreateDirectory(subpath2);
+
+                var subpath3 = Path.Combine(testPath, "folder_containing_invalid_scripts");
+                Directory.CreateDirectory(subpath3);
+
+                var index = 0;
+                foreach (var scriptName in assembly.GetManifestResourceNames().Where(f => f.Contains(".sql")))
+                {
+                    using (var stream = assembly.GetManifestResourceStream(scriptName))
+                    {
+                        // split files in three separate version directories
+                        var destPath = index < 3 ?
+                            subpath1 :
+                            index > 3 ?
+                                subpath3 :
+                                subpath2;
+
+                        var filePath = Path.Combine(destPath, scriptName);
+                        using (var writer = new FileStream(filePath, FileMode.CreateNew))
+                        {
+
+                            stream.CopyTo(writer);
+                            writer.Flush();
+                            writer.Close();
+                        }
+                        stream.Close();
+                    }
+
+                    index++;
+                }
+            }
+
+            public override void When()
+            {
+                filesToExecute = Subject.GetScripts(Arg.Any<IConnectionManager>());
+            }
+
+            [Then]
+            public void the_filter_should_have_been_executed()
+            {
+                Assert.IsTrue(_FilterExecuted);
+            }
+
+            [Then]
+            public void the_target_version_and_filter_should_have_been_applied_and_order_is_correct()
+            {
+                Assert.That(filesToExecute.Count() == 2);
+                Assert.That(filesToExecute.ElementAt(0).Name.EndsWith(@"20150101-apple\DbUp.Tests.TestScripts.Script20110301_1_Test1.sql"));
+                Assert.That(filesToExecute.ElementAt(1).Name.EndsWith(@"20150101-apple\DbUp.Tests.TestScripts.Script20110302_1_Test3.sql"));
+            }
+        }
+
+        [TestFixture]
+        public class when_returning_scripts_from_version_folders_and_using_an_invalid_target_version : SpecificationFor<VersionFoldersScriptProvider>
+        {
+            private string testPath = null;
+            private Func<string, bool> filter = null;
+            private string targetVersion;
+            private IEnumerable<SqlScript> filesToExecute;
+            private bool invalidOperationExceptionThrown = false;
+
+            public override VersionFoldersScriptProvider Given()
+            {
+                CreateTestFiles();
+
+                targetVersion = "INVALID";
+
+                return new VersionFoldersScriptProvider(testPath, filter, targetVersion);
+            }
+
+            [TearDown]
+            public void CleanUp()
+            {
+                Directory.Delete(testPath, true);
+            }
+
+            private void CreateTestFiles()
+            {
+                var assembly = Assembly.GetExecutingAssembly();
+                var directory = new FileInfo(assembly.Location).DirectoryName;
+
+                testPath = Path.Combine(directory, "sqlfiles");
+                Directory.CreateDirectory(testPath);
+
+                var subpath1 = Path.Combine(testPath, "3.4");
+                Directory.CreateDirectory(subpath1);
+
+                foreach (var scriptName in assembly.GetManifestResourceNames().Where(f => f.Contains(".sql")))
+                {
+                    using (var stream = assembly.GetManifestResourceStream(scriptName))
+                    {
+                        // split files in two separate version directories
+                        var filePath = Path.Combine(subpath1, scriptName);
+                        using (var writer = new FileStream(filePath, FileMode.CreateNew))
+                        {
+
+                            stream.CopyTo(writer);
+                            writer.Flush();
+                            writer.Close();
+                        }
+                        stream.Close();
+                    }
+                }
+            }
+
+            public override void When()
+            {
+                try
+                {
+                    filesToExecute = Subject.GetScripts(Arg.Any<IConnectionManager>());
+                }
+                catch (InvalidOperationException)
+                {
+                    invalidOperationExceptionThrown = true;
+                }
+            }
+
+            [Then]
+            public void should_throw_on_invalid_target_version()
+            {
+                Assert.That(invalidOperationExceptionThrown);
+            }
+        }
+
+        [TestFixture]
+        public class when_returning_scripts_from_ambiguous_folder_versions_and_using_a_target_version : SpecificationFor<VersionFoldersScriptProvider>
+        {
+            private string testPath = null;
+            private Func<string, bool> filter = null;
+            private string targetVersion = "20150101_1-apple";
+            private IEnumerable<SqlScript> filesToExecute;
+            private bool invalidOperationExceptionThrown = false;
+
+            public override VersionFoldersScriptProvider Given()
+            {
+                CreateTestFiles();
+
+                return new VersionFoldersScriptProvider(testPath, filter, targetVersion);
+            }
+
+            [TearDown]
+            public void CleanUp()
+            {
+                Directory.Delete(testPath, true);
+            }
+
+            private void CreateTestFiles()
+            {
+                var assembly = Assembly.GetExecutingAssembly();
+                var directory = new FileInfo(assembly.Location).DirectoryName;
+
+                testPath = Path.Combine(directory, "sqlfiles");
+                Directory.CreateDirectory(testPath);
+
+                var subpath1 = Path.Combine(testPath, "20150101_1-apple");
+                Directory.CreateDirectory(subpath1);
+
+                var subpath2 = Path.Combine(testPath, "20150101-1-banana");
+                Directory.CreateDirectory(subpath2);
+
+                var index = 0;
+                foreach (var scriptName in assembly.GetManifestResourceNames().Where(f => f.Contains(".sql")))
+                {
+                    using (var stream = assembly.GetManifestResourceStream(scriptName))
+                    {
+                        // split files in two separate version directories
+                        var destPath = index < 1 ? subpath1 : subpath2;
+
+                        var filePath = Path.Combine(destPath, scriptName);
+                        using (var writer = new FileStream(filePath, FileMode.CreateNew))
+                        {
+
+                            stream.CopyTo(writer);
+                            writer.Flush();
+                            writer.Close();
+                        }
+                        stream.Close();
+                    }
+
+                    index++;
+                }
+            }
+
+            public override void When()
+            {
+                try
+                {
+                    filesToExecute = Subject.GetScripts(Arg.Any<IConnectionManager>());
+                }
+                catch (InvalidOperationException)
+                {
+                    invalidOperationExceptionThrown = true;
+                }
+            }
+
+            [Then]
+            public void should_throw_on_ambiguous_version_folders()
+            {
+                Assert.That(invalidOperationExceptionThrown);
+            }
+        }
+    }
+}

--- a/src/DbUp/Builder/StandardExtensions.cs
+++ b/src/DbUp/Builder/StandardExtensions.cs
@@ -234,7 +234,7 @@ public static class StandardExtensions
     }
 
     /// <summary>
-    /// Adds all scripts from a folder containing version folders on the file system, with a version limit.
+    /// Adds all scripts from a folder containing version folders on the file system, with a target version.
     /// </summary>
     /// <param name="builder">The builder.</param>
     /// <param name="path">The directory path.</param>
@@ -248,7 +248,21 @@ public static class StandardExtensions
     }
 
     /// <summary>
-    /// Adds all scripts from a folder containing version folders on the file system, with a version limit and custom encoding.
+    /// Adds all scripts from a folder containing version folders on the file system, with a custom filter.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="path">The directory path.</param>
+    /// <param name="filter">The filter. Use the static <see cref="Filters"/> class to get some pre-defined filters.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsFromVersionFolders(this UpgradeEngineBuilder builder, string path, Func<string, bool> filter)
+    {
+        return WithScripts(builder, new VersionFoldersScriptProvider(path, filter));
+    }
+
+    /// <summary>
+    /// Adds all scripts from a folder containing version folders on the file system, with a target version and custom encoding.
     /// </summary>
     /// <param name="builder">The builder.</param>
     /// <param name="path">The directory path.</param>
@@ -263,7 +277,7 @@ public static class StandardExtensions
     }
 
     /// <summary>
-    /// Adds all scripts from a folder containing version folders on the file system, with a version limit and custom filter.
+    /// Adds all scripts from a folder containing version folders on the file system, with a target version and custom filter.
     /// </summary>
     /// <param name="builder">The builder.</param>
     /// <param name="path">The directory path.</param>
@@ -278,7 +292,22 @@ public static class StandardExtensions
     }
 
     /// <summary>
-    /// Adds all scripts from a folder containing version folders on the file system, with a version limit, a custom encoding and a custom filter.
+    /// Adds all scripts from a folder containing version folders on the file system, with a custom encoding and a custom filter.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="path">The directory path.</param>
+    /// <param name="encoding">The encoding.</param>
+    /// <param name="filter">The filter. Use the static <see cref="Filters"/> class to get some pre-defined filters.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsFromVersionFolders(this UpgradeEngineBuilder builder, string path, Encoding encoding, Func<string, bool> filter)
+    {
+        return WithScripts(builder, new VersionFoldersScriptProvider(path, encoding, filter));
+    }
+
+    /// <summary>
+    /// Adds all scripts from a folder containing version folders on the file system, with a target version, a custom encoding and a custom filter.
     /// </summary>
     /// <param name="builder">The builder.</param>
     /// <param name="path">The directory path.</param>

--- a/src/DbUp/Builder/StandardExtensions.cs
+++ b/src/DbUp/Builder/StandardExtensions.cs
@@ -133,7 +133,7 @@ public static class StandardExtensions
     /// </returns>
     public static UpgradeEngineBuilder WithScripts(this UpgradeEngineBuilder builder, params SqlScript[] scripts)
     {
-        return WithScripts(builder, (IEnumerable<SqlScript>)scripts);
+        return WithScripts(builder, (IEnumerable<SqlScript>) scripts);
     }
 
     /// <summary>
@@ -218,6 +218,79 @@ public static class StandardExtensions
     public static UpgradeEngineBuilder WithScriptsFromFileSystem(this UpgradeEngineBuilder builder, string path, Func<string, bool> filter, Encoding encoding)
     {
         return WithScripts(builder, new FileSystemScriptProvider(path, filter, encoding));
+    }
+
+    /// <summary>
+    /// Adds all scripts from a folder containing version folders on the file system.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="path">The directory path.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsFromVersionFolders(this UpgradeEngineBuilder builder, string path)
+    {
+        return WithScripts(builder, new VersionFoldersScriptProvider(path));
+    }
+
+    /// <summary>
+    /// Adds all scripts from a folder containing version folders on the file system, with a version limit.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="path">The directory path.</param>
+    /// <param name="targetVersion">Exclude version folders with a higher version number.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsFromVersionFolders(this UpgradeEngineBuilder builder, string path, string targetVersion)
+    {
+        return WithScripts(builder, new VersionFoldersScriptProvider(path, targetVersion));
+    }
+
+    /// <summary>
+    /// Adds all scripts from a folder containing version folders on the file system, with a version limit and custom encoding.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="path">The directory path.</param>
+    /// <param name="encoding">The encoding.</param>
+    /// <param name="targetVersion">Exclude version folders with a higher version number.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsFromVersionFolders(this UpgradeEngineBuilder builder, string path, Encoding encoding, string targetVersion)
+    {
+        return WithScripts(builder, new VersionFoldersScriptProvider(path, targetVersion));
+    }
+
+    /// <summary>
+    /// Adds all scripts from a folder containing version folders on the file system, with a version limit and custom filter.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="path">The directory path.</param>
+    /// <param name="filter">The filter. Use the static <see cref="Filters"/> class to get some pre-defined filters.</param>
+    /// <param name="targetVersion">Exclude version folders with a higher version number.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsFromVersionFolders(this UpgradeEngineBuilder builder, string path, Func<string, bool> filter, string targetVersion)
+    {
+        return WithScripts(builder, new VersionFoldersScriptProvider(path, filter, targetVersion));
+    }
+
+    /// <summary>
+    /// Adds all scripts from a folder containing version folders on the file system, with a version limit, a custom encoding and a custom filter.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="path">The directory path.</param>
+    /// <param name="encoding">The encoding.</param>
+    /// <param name="filter">The filter. Use the static <see cref="Filters"/> class to get some pre-defined filters.</param>
+    /// <param name="targetVersion">Exclude version folders with a higher version number.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsFromVersionFolders(this UpgradeEngineBuilder builder, string path, Encoding encoding, Func<string, bool> filter, string targetVersion)
+    {
+        return WithScripts(builder, new VersionFoldersScriptProvider(path, encoding, filter, targetVersion));
     }
 
     /// <summary>

--- a/src/DbUp/DbUp.csproj
+++ b/src/DbUp/DbUp.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Helpers\Filters.cs" />
     <Compile Include="Helpers\NullJournal.cs" />
     <Compile Include="ScriptProviders\EmbeddedScriptsProvider.cs" />
+    <Compile Include="ScriptProviders\VersionFoldersScriptProvider.cs" />
     <Compile Include="SupportedDatabasesForEnsureDatabase.cs" />
     <Compile Include="Support\Firebird\FirebirdTableJournal.cs" />
     <Compile Include="Support\MySql\MySqlITableJournal.cs" />

--- a/src/DbUp/ScriptProviders/VersionFoldersScriptProvider.cs
+++ b/src/DbUp/ScriptProviders/VersionFoldersScriptProvider.cs
@@ -96,7 +96,7 @@ namespace DbUp.ScriptProviders
         /// <exception cref="InvalidOperationException">Thrown when multiple subfolder names parse to the same version number.</exception>
         public IEnumerable<SqlScript> GetScripts(IConnectionManager connectionManager)
         {
-            return targetVersion == null ?
+            return string.IsNullOrEmpty(targetVersion) ?
                 GetScriptsWithoutTargetVersion() :
                 GetScriptsWithTargetVersion();
         }

--- a/src/DbUp/ScriptProviders/VersionFoldersScriptProvider.cs
+++ b/src/DbUp/ScriptProviders/VersionFoldersScriptProvider.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using DbUp.Engine;
+using DbUp.Engine.Transactions;
+
+namespace DbUp.ScriptProviders
+{
+    ///<summary>
+    /// Alternate <see cref="IScriptProvider"/> implementation which retrieves upgrade scripts from version folders in a directory.
+    ///</summary>
+    public class VersionFoldersScriptProvider : IScriptProvider
+    {
+        private readonly string directoryPath;
+        private readonly Encoding encoding;
+        private readonly Func<string, bool> filter;
+        private readonly string targetVersion;
+
+        ///<param name="directoryPath">Path to SQL upgrade scripts</param>
+        public VersionFoldersScriptProvider(string directoryPath)
+        {
+            this.directoryPath = directoryPath;
+            this.filter = null;
+            this.encoding = Encoding.Default;
+            this.targetVersion = null;
+        }
+
+        ///<param name="directoryPath">Path to SQL upgrade scripts</param>
+        ///<param name="targetVersion">Exclude scripts in subfolders with a higher version number.</param>
+        public VersionFoldersScriptProvider(string directoryPath, string targetVersion)
+        {
+            this.directoryPath = directoryPath;
+            this.filter = null;
+            this.encoding = Encoding.Default;
+            this.targetVersion = targetVersion;
+        }
+
+        ///<param name="directoryPath">Path to SQL upgrade scripts</param>
+        ///<param name="encoding">The encoding.</param>
+        ///<param name="targetVersion">Exclude scripts in subfolders with a higher version number.</param>
+        public VersionFoldersScriptProvider(string directoryPath, Encoding encoding, string targetVersion)
+        {
+            this.directoryPath = directoryPath;
+            this.encoding = encoding;
+            this.targetVersion = targetVersion;
+        }
+
+        ///<param name="directoryPath">Path to SQL upgrade scripts</param>
+        ///<param name="filter">The filter.</param>
+        ///<param name="targetVersion">Exclude scripts in subfolders with a higher version number.</param>
+        public VersionFoldersScriptProvider(string directoryPath, Func<string, bool> filter, string targetVersion)
+        {
+            this.directoryPath = directoryPath;
+            this.filter = filter;
+            this.encoding = Encoding.Default;
+            this.targetVersion = targetVersion;
+        }
+
+        ///<param name="directoryPath">Path to SQL upgrade scripts</param>
+        ///<param name="encoding">The encoding.</param>
+        ///<param name="filter">The filter.</param>
+        ///<param name="targetVersion">Exclude scripts in subfolders with a higher version number.</param>
+        public VersionFoldersScriptProvider(string directoryPath, Encoding encoding, Func<string, bool> filter, string targetVersion)
+        {
+            this.directoryPath = directoryPath;
+            this.filter = filter;
+            this.encoding = encoding;
+            this.targetVersion = targetVersion;
+        }
+
+        /// <exception cref="InvalidOperationException">Thrown when multiple subfolder names parse to the same version number.</exception>
+        public IEnumerable<SqlScript> GetScripts(IConnectionManager connectionManager)
+        {
+            return targetVersion == null ?
+                GetScriptsWithoutTargetVersion() :
+                GetScriptsWithTargetVersion();
+        }
+
+        private IEnumerable<SqlScript> GetScriptsWithoutTargetVersion()
+        {
+            var scripts = new List<SqlScript>();
+
+            foreach (var folderPath in Directory.GetDirectories(directoryPath))
+            {
+                var folderName = new DirectoryInfo(folderPath).Name;
+                scripts.AddRange(GetScriptsFromFolder(folderName));
+            }
+
+            return scripts;
+        }
+
+        /// <summary>
+        /// Excludes scripts from version folders with a version higher than target version.
+        /// A <see cref="filter"/> must be supplied for folders to exclude.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when an unparseable folder version is encountered, or when multiple subfolder names parse to the same version number.</exception>
+        private IEnumerable<SqlScript> GetScriptsWithTargetVersion()
+        {
+            var folderNames = Directory.GetDirectories(directoryPath)
+                .Select(d => new DirectoryInfo(d).Name);
+
+            // filter on folder names
+            if (filter != null)
+            {
+                folderNames = folderNames.Where(filter);
+            }
+
+            var scripts = new List<SqlScript>();
+
+            if (folderNames.Any())
+            {
+                Version target = ParseVersion(targetVersion);
+                var parsedVersions = new List<Version>();
+
+                foreach (var folderName in folderNames)
+                {
+                    // Expecting all encountered folder names to be parseable. 
+                    var folderVersion = ParseVersion(folderName);
+
+                    if (folderVersion <= target)
+                    {
+                        if (parsedVersions.Contains(folderVersion))
+                        {
+                            throw new InvalidOperationException(string.Format("Version '{0}' parsed for folder '{1}' is ambiguous.", folderVersion, folderName));
+                        }
+
+                        scripts.AddRange(GetScriptsFromFolder(folderName));
+                        parsedVersions.Add(folderVersion);
+                    }
+                }
+            }
+
+            return scripts;
+        }
+
+        /// <summary>
+        /// Get scripts from the specified version folder. 
+        /// The version folder name is prefixed to the scriptname to make scripts with duplicate names unique when from different folders.
+        /// </summary>
+        /// <param name="folder">name of subfolder within directory path</param>
+        private IEnumerable<SqlScript> GetScriptsFromFolder(string folder)
+        {
+            var absoluteFolderPath = Path.Combine(directoryPath, folder);
+
+            var folderedFileNames = Directory.GetFiles(absoluteFolderPath, "*.sql")
+                .Select(f => Path.Combine(folder, new FileInfo(f).Name))
+                .AsEnumerable();
+
+            // filter on folder\file combination
+            if (this.filter != null)
+            {
+                folderedFileNames = folderedFileNames.Where(filter);
+            }
+
+            // load file contents
+            var sqlScripts = new List<SqlScript>();
+
+            foreach (var folderedFileName in folderedFileNames)
+            {
+                var filePath = Path.Combine(directoryPath, folderedFileName);
+                using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+                {
+                    sqlScripts.Add(SqlScript.FromStream(folderedFileName, fileStream, encoding));
+                }
+            }
+
+            return sqlScripts;
+        }
+
+        private static Version ParseVersion(string str)
+        {
+            Version parsed;
+
+            if (!TryParseVersion(str, out parsed))
+            {
+                throw new InvalidOperationException(string.Format("Error parsing version from string '{0}'.", str));
+            }
+            return parsed;
+        }
+
+        private static bool TryParseVersion(string str, out Version parsed)
+        {
+            // Find at least 1 and max 4 delimited decimals at string start, otherwise fail the entire match.
+            var regex = new Regex(@"^(?>0*(\d+)(?:[\^_\-\.,~ ]+0*(\d+))?(?:[\^_\-\.,~ ]+0*(\d+))?(?:[\^_\-\.,~ ]+0*(\d+))?)(?![\^_\-\.,~ ]+\d+)");
+            var result = regex.Match(str);
+
+            if (result.Success)
+            {
+                int val;
+                int major = int.Parse(result.Groups[ 1 ].Value);
+                int minor = int.TryParse(result.Groups[ 2 ].Value, out val) ? val : 0;
+                int build = int.TryParse(result.Groups[ 3 ].Value, out val) ? val : 0;
+                int revision = int.TryParse(result.Groups[ 4 ].Value, out val) ? val : 0;
+
+                parsed = new Version(major, minor, build, revision);
+            }
+            else
+            {
+                parsed = new Version();
+            }
+
+            return result.Success;
+        }
+    }
+}

--- a/src/DbUp/ScriptProviders/VersionFoldersScriptProvider.cs
+++ b/src/DbUp/ScriptProviders/VersionFoldersScriptProvider.cs
@@ -39,13 +39,35 @@ namespace DbUp.ScriptProviders
         }
 
         ///<param name="directoryPath">Path to SQL upgrade scripts</param>
+        ///<param name="filter">The filter.</param>
+        public VersionFoldersScriptProvider(string directoryPath, Func<string, bool> filter)
+        {
+            this.directoryPath = directoryPath;
+            this.filter = filter;
+            this.encoding = Encoding.Default;
+            this.targetVersion = null;
+        }
+
+        ///<param name="directoryPath">Path to SQL upgrade scripts</param>
         ///<param name="encoding">The encoding.</param>
         ///<param name="targetVersion">Exclude scripts in subfolders with a higher version number.</param>
         public VersionFoldersScriptProvider(string directoryPath, Encoding encoding, string targetVersion)
         {
             this.directoryPath = directoryPath;
+            this.filter = null;
             this.encoding = encoding;
             this.targetVersion = targetVersion;
+        }
+
+        ///<param name="directoryPath">Path to SQL upgrade scripts</param>
+        ///<param name="encoding">The encoding.</param>
+        ///<param name="targetVersion">Exclude scripts in subfolders with a higher version number.</param>
+        public VersionFoldersScriptProvider(string directoryPath, Encoding encoding, Func<string, bool> filter)
+        {
+            this.directoryPath = directoryPath;
+            this.filter = filter;
+            this.encoding = encoding;
+            this.targetVersion = null;
         }
 
         ///<param name="directoryPath">Path to SQL upgrade scripts</param>


### PR DESCRIPTION
For use in Octopus Deploy we created a specialized file system provider to improve support for our build scripts folder structure. 
DbUp is a very useful project to us, so i hope i can help providing some extra value here. Feel free to cherry pick.

This provider adds the following features:

### Read scripts from a folder containing one subfolder per version
Example folder structure:
```
my-script-root-folder\
   1.0\
        1_apple.sql
        2_banana.sql
   1.0.1\
        1_apple.sql
        2_pear.sql
   2.0\
        apple.sql
        banana.sql
```
The found scripts are flattened to one list by combining the relative folder name with the script name. In this example, the resulting ordered set of scripts of will be:
```
1.0\1_apple.sql
1.0\2_banana.sql
1.0.1\1_apple.sql
1.0.1\2_pear.sql
2.0\apple.sql
2.0\banana.sql
```
### Specify a target version
Use semantic versioning to exclude scripts from folders from versions newer than the target version. This makes it possible to use the same scriptbase for patch and release deploys. To make this possible, the foldersnames must be parseable to a version (i.e. contains 1 - 4 delimited decimals),

In the example above, a target version of '1.0.1' will result in the following ordered set of scripts:
```
1.0\1_apple.sql
1.0\2_banana.sql
1.0.1\1_apple.sql
1.0.1\2_pear.sql
```
### Misc.
##### The script provider filter is applied twice, in consequtive order:
1. To the folder name
2. To the effective scriptname

##### Unit tests are added


