### PR TITLE
Be explicit about date formatting

### DIFF
--- a/src/DbUp.Tests/TestInfrastructure/RecordingDbDataParameter.cs
+++ b/src/DbUp.Tests/TestInfrastructure/RecordingDbDataParameter.cs
@@ -18,7 +18,18 @@ namespace DbUp.Tests.TestInfrastructure
 
         public override string ToString()
         {
-            return string.Format("{0}={1}", ParameterName, Value);
+            var format = "{0}={1}";
+            if ((DbType == DbType.Date)
+                || (DbType == DbType.DateTime)
+                || (DbType == DbType.DateTime2)
+                || (DbType == DbType.DateTimeOffset)
+                || (DbType == DbType.AnsiString // If DbType is not explicitly set it will default to AnsiString so check our Value's type
+                    && (Value != null && (Value.GetType() == typeof(DateTime) || Value.GetType() == typeof(DateTimeOffset)))))
+            {
+                format = "{0}={1:dd\\/MM\\/yyyy hh\\:mm\\:ss}"; // Be explicit and don't rely on the system's formatting for dates so we can scrub them out later
+            }
+
+            return string.Format(format, ParameterName, Value);
         }
     }
 }

--- a/src/DbUp.Tests/TestInfrastructure/Scrubbers.cs
+++ b/src/DbUp.Tests/TestInfrastructure/Scrubbers.cs
@@ -7,7 +7,7 @@ namespace DbUp.Tests.TestInfrastructure
     {
         public static string ScrubDates(string arg)
         {
-            return Regex.Replace(arg, @"\d?\d/\d?\d/\d?\d?\d\d \d?\d:\d\d:\d\d ..", "<date>");
+            return Regex.Replace(arg, @"\d?\d/\d?\d/\d?\d?\d\d \d?\d:\d\d:\d\d", "<date>");
         }
     }
 }


### PR DESCRIPTION
On systems with non-standard date formats configured the tests would fail because we relied upon later scrubbing out a specific date format (dd/MM/yyyy hh:mm:ss). Detect that we are recording a date-based DbParameter and write the value with an explicit format.