### PR TITLE
Alter Journal Table Creation To Uniquely Name Primary Key

### DIFF
--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SqlCe.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SqlCe.approved.txt
@@ -6,7 +6,7 @@ Dispose command
 Execute scalar command: select count(*) from [SchemaVersions]
 Dispose command
 Execute non query command: create table [SchemaVersions] (
-	[Id] int identity(1,1) not null constraint PK_SchemaVersions_Id primary key,
+	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
 )

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SqlServer.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SqlServer.approved.txt
@@ -6,7 +6,7 @@ Dispose command
 Execute scalar command: select count(*) from [SchemaVersions]
 Dispose command
 Execute non query command: create table [SchemaVersions] (
-	[Id] int identity(1,1) not null constraint PK_SchemaVersions_Id primary key,
+	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
 )

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.Firebird.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.Firebird.approved.txt
@@ -1,0 +1,28 @@
+﻿Open connection
+Execute scalar command: select count(*) from TestSchemaVersions
+Dispose command
+Execute non query command: script1contents
+Dispose command
+Execute scalar command: select count(*) from TestSchemaVersions
+Dispose command
+Execute non query command: CREATE TABLE TestSchemaVersions
+                                    (
+                                        schemaversionsid INTEGER NOT NULL,
+                                        scriptname VARCHAR(255) NOT NULL,
+                                        applied TIMESTAMP NOT NULL,
+                                        CONSTRAINT pk_TestSchemaVersions_id PRIMARY KEY (schemaversionsid)
+                                    )
+Dispose command
+Execute non query command: CREATE SEQUENCE GEN_TestSchemaVersionsID
+Dispose command
+Execute non query command: CREATE TRIGGER BI_TestSchemaVersionsID FOR TestSchemaVersions ACTIVE BEFORE INSERT POSITION 0 AS BEGIN
+                                        if (new.schemaversionsid is null or (new.schemaversionsid = 0)) then new.schemaversionsid = gen_id(GEN_TestSchemaVersionsID,1);
+                                  END;
+Dispose command
+Create parameter
+Add parameter to command: scriptName=Script0001.sql
+Create parameter
+Add parameter to command: applied=<date>
+Execute non query command: insert into TestSchemaVersions (ScriptName, Applied) values (@scriptName, @applied)
+Dispose command
+Dispose connection

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.MySql.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.MySql.approved.txt
@@ -1,0 +1,21 @@
+﻿Open connection
+Execute scalar command: select count(*) from `test`.`TestSchemaVersions`
+Dispose command
+Execute non query command: script1contents
+Dispose command
+Execute scalar command: select count(*) from `test`.`TestSchemaVersions`
+Dispose command
+Execute non query command: CREATE TABLE `test`.`TestSchemaVersions` 
+                    (
+                        `schemaversionid` INT NOT NULL AUTO_INCREMENT,
+                        `scriptname` VARCHAR(255) NOT NULL,
+                        `applied` TIMESTAMP NOT NULL,
+                        PRIMARY KEY (`schemaversionid`));
+Dispose command
+Create parameter
+Add parameter to command: scriptName=Script0001.sql
+Create parameter
+Add parameter to command: applied=<date>
+Execute non query command: insert into `test`.`TestSchemaVersions` (ScriptName, Applied) values (@scriptName, @applied)
+Dispose command
+Dispose connection

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.PostgreSQL.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.PostgreSQL.approved.txt
@@ -1,22 +1,22 @@
 ﻿Open connection
-Execute scalar command: select count(*) from "schemaversions"
+Execute scalar command: select count(*) from "test"."TestSchemaVersions"
 Dispose command
 Execute non query command: script1contents
 Dispose command
-Execute scalar command: select count(*) from "schemaversions"
+Execute scalar command: select count(*) from "test"."TestSchemaVersions"
 Dispose command
-Execute non query command: CREATE TABLE "schemaversions"
+Execute non query command: CREATE TABLE "test"."TestSchemaVersions"
                               (
                                 schemaversionsid serial NOT NULL,
                                 scriptname character varying(255) NOT NULL,
                                 applied timestamp without time zone NOT NULL,
-                                CONSTRAINT "PK_schemaversions_Id" PRIMARY KEY (schemaversionsid)
+                                CONSTRAINT "PK_TestSchemaVersions_Id" PRIMARY KEY (schemaversionsid)
                               )
 Dispose command
 Create parameter
 Add parameter to command: scriptName=Script0001.sql
 Create parameter
 Add parameter to command: applied=<date>
-Execute non query command: insert into "schemaversions" (ScriptName, Applied) values (@scriptName, @applied)
+Execute non query command: insert into "test"."TestSchemaVersions" (ScriptName, Applied) values (@scriptName, @applied)
 Dispose command
 Dispose connection

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SQLite.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SQLite.approved.txt
@@ -1,0 +1,20 @@
+﻿Open connection
+Execute scalar command: select count(*) from [TestSchemaVersions]
+Dispose command
+Execute non query command: script1contents
+Dispose command
+Execute scalar command: select count(*) from [TestSchemaVersions]
+Dispose command
+Execute non query command: CREATE TABLE [TestSchemaVersions] (
+	SchemaVersionID INTEGER CONSTRAINT 'PK_TestSchemaVersions_SchemaVersionID' PRIMARY KEY AUTOINCREMENT NOT NULL,
+	ScriptName TEXT NOT NULL,
+	Applied DATETIME NOT NULL
+)
+Dispose command
+Create parameter
+Add parameter to command: scriptName=Script0001.sql
+Create parameter
+Add parameter to command: applied=<date>
+Execute non query command: insert into [TestSchemaVersions] (ScriptName, Applied) values (@scriptName, @applied)
+Dispose command
+Dispose connection

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlCe.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlCe.approved.txt
@@ -1,0 +1,20 @@
+﻿Open connection
+Execute scalar command: select count(*) from [test].[TestSchemaVersions]
+Dispose command
+Execute non query command: script1contents
+Dispose command
+Execute scalar command: select count(*) from [test].[TestSchemaVersions]
+Dispose command
+Execute non query command: create table [test].[TestSchemaVersions] (
+	[Id] int identity(1,1) not null constraint [test].[PK_TestSchemaVersions_Id] primary key,
+	[ScriptName] nvarchar(255) not null,
+	[Applied] datetime not null
+)
+Dispose command
+Create parameter
+Add parameter to command: scriptName=Script0001.sql
+Create parameter
+Add parameter to command: applied=<date>
+Execute non query command: insert into [test].[TestSchemaVersions] (ScriptName, Applied) values (@scriptName, @applied)
+Dispose command
+Dispose connection

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlCe.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlCe.approved.txt
@@ -6,7 +6,7 @@ Dispose command
 Execute scalar command: select count(*) from [test].[TestSchemaVersions]
 Dispose command
 Execute non query command: create table [test].[TestSchemaVersions] (
-	[Id] int identity(1,1) not null constraint [test].[PK_TestSchemaVersions_Id] primary key,
+	[Id] int identity(1,1) not null constraint [PK_TestSchemaVersions_Id] primary key,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
 )

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlServer.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlServer.approved.txt
@@ -1,0 +1,20 @@
+﻿Open connection
+Execute scalar command: select count(*) from [test].[TestSchemaVersions]
+Dispose command
+Execute non query command: script1contents
+Dispose command
+Execute scalar command: select count(*) from [test].[TestSchemaVersions]
+Dispose command
+Execute non query command: create table [test].[TestSchemaVersions] (
+	[Id] int identity(1,1) not null constraint [test].[PK_TestSchemaVersions_Id] primary key,
+	[ScriptName] nvarchar(255) not null,
+	[Applied] datetime not null
+)
+Dispose command
+Create parameter
+Add parameter to command: scriptName=Script0001.sql
+Create parameter
+Add parameter to command: applied=<date>
+Execute non query command: insert into [test].[TestSchemaVersions] (ScriptName, Applied) values (@scriptName, @applied)
+Dispose command
+Dispose connection

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlServer.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlServer.approved.txt
@@ -6,7 +6,7 @@ Dispose command
 Execute scalar command: select count(*) from [test].[TestSchemaVersions]
 Dispose command
 Execute non query command: create table [test].[TestSchemaVersions] (
-	[Id] int identity(1,1) not null constraint [test].[PK_TestSchemaVersions_Id] primary key,
+	[Id] int identity(1,1) not null constraint [PK_TestSchemaVersions_Id] primary key,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
 )

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.PostgreSQL.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.PostgreSQL.approved.txt
@@ -10,7 +10,7 @@ Execute non query command: CREATE TABLE "schemaversions"
                                 schemaversionsid serial NOT NULL,
                                 scriptname character varying(255) NOT NULL,
                                 applied timestamp without time zone NOT NULL,
-                                CONSTRAINT pk_schemaversions_id PRIMARY KEY (schemaversionsid)
+                                CONSTRAINT "PK_schemaversions_Id" PRIMARY KEY (schemaversionsid)
                               )
 Dispose command
 Create parameter

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SqlCe.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SqlCe.approved.txt
@@ -6,7 +6,7 @@ Dispose command
 Execute scalar command: select count(*) from [SchemaVersions]
 Dispose command
 Execute non query command: create table [SchemaVersions] (
-	[Id] int identity(1,1) not null constraint PK_SchemaVersions_Id primary key,
+	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
 )

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SqlServer.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SqlServer.approved.txt
@@ -6,7 +6,7 @@ Dispose command
 Execute scalar command: select count(*) from [SchemaVersions]
 Dispose command
 Execute non query command: create table [SchemaVersions] (
-	[Id] int identity(1,1) not null constraint PK_SchemaVersions_Id primary key,
+	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
 )

--- a/src/DbUp.Tests/DbUp.approved.cs
+++ b/src/DbUp.Tests/DbUp.approved.cs
@@ -325,7 +325,7 @@ namespace DbUp.Support.SQLite
     public sealed class SQLiteTableJournal : DbUp.Support.SqlServer.SqlTableJournal
     {
         public SQLiteTableJournal(System.Func<DbUp.Engine.Transactions.IConnectionManager> connectionManager, System.Func<DbUp.Engine.Output.IUpgradeLog> logger, string table) { }
-        protected override string CreatePrimaryKeyName(string schema, string table) { }
+        protected override string CreatePrimaryKeyName(string table) { }
         protected override string CreateTableSql(string schema, string table) { }
     }
 }
@@ -388,7 +388,7 @@ namespace DbUp.Support.SqlServer
     public class SqlTableJournal : DbUp.Engine.IJournal
     {
         public SqlTableJournal(System.Func<DbUp.Engine.Transactions.IConnectionManager> connectionManager, System.Func<DbUp.Engine.Output.IUpgradeLog> logger, string schema, string table) { }
-        protected virtual string CreatePrimaryKeyName(string schema, string table) { }
+        protected virtual string CreatePrimaryKeyName(string table) { }
         protected virtual string CreateTableName(string schema, string table) { }
         protected virtual string CreateTableSql(string schema, string table) { }
         public string[] GetExecutedScripts() { }

--- a/src/DbUp.Tests/DbUp.approved.cs
+++ b/src/DbUp.Tests/DbUp.approved.cs
@@ -325,7 +325,8 @@ namespace DbUp.Support.SQLite
     public sealed class SQLiteTableJournal : DbUp.Support.SqlServer.SqlTableJournal
     {
         public SQLiteTableJournal(System.Func<DbUp.Engine.Transactions.IConnectionManager> connectionManager, System.Func<DbUp.Engine.Output.IUpgradeLog> logger, string table) { }
-        protected override string CreateTableSql(string tableName) { }
+        protected override string CreatePrimaryKeyName(string schema, string table) { }
+        protected override string CreateTableSql(string schema, string table) { }
     }
 }
 namespace DbUp.Support.SqlServer
@@ -387,9 +388,11 @@ namespace DbUp.Support.SqlServer
     public class SqlTableJournal : DbUp.Engine.IJournal
     {
         public SqlTableJournal(System.Func<DbUp.Engine.Transactions.IConnectionManager> connectionManager, System.Func<DbUp.Engine.Output.IUpgradeLog> logger, string schema, string table) { }
-        protected virtual string CreateTableSql(string tableName) { }
+        protected virtual string CreatePrimaryKeyName(string schema, string table) { }
+        protected virtual string CreateTableName(string schema, string table) { }
+        protected virtual string CreateTableSql(string schema, string table) { }
         public string[] GetExecutedScripts() { }
-        protected virtual string GetExecutedScriptsSql(string table) { }
+        protected virtual string GetExecutedScriptsSql(string schema, string table) { }
         public void StoreExecutedScript(DbUp.Engine.SqlScript script) { }
     }
 }

--- a/src/DbUp.Tests/TransactionScenarios.UsingNoTransactionsScenario.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingNoTransactionsScenario.approved.txt
@@ -6,7 +6,7 @@ Dispose command
 Execute scalar command: select count(*) from [SchemaVersions]
 Dispose command
 Execute non query command: create table [SchemaVersions] (
-	[Id] int identity(1,1) not null constraint PK_SchemaVersions_Id primary key,
+	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
 )
@@ -22,7 +22,7 @@ Dispose command
 Execute scalar command: select count(*) from [SchemaVersions]
 Dispose command
 Execute non query command: create table [SchemaVersions] (
-	[Id] int identity(1,1) not null constraint PK_SchemaVersions_Id primary key,
+	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
 )

--- a/src/DbUp.Tests/TransactionScenarios.UsingSingleTransactionScenarioSuccess.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingSingleTransactionScenarioSuccess.approved.txt
@@ -7,7 +7,7 @@ Dispose command
 Execute scalar command: select count(*) from [SchemaVersions]
 Dispose command
 Execute non query command: create table [SchemaVersions] (
-	[Id] int identity(1,1) not null constraint PK_SchemaVersions_Id primary key,
+	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
 )
@@ -23,7 +23,7 @@ Dispose command
 Execute scalar command: select count(*) from [SchemaVersions]
 Dispose command
 Execute non query command: create table [SchemaVersions] (
-	[Id] int identity(1,1) not null constraint PK_SchemaVersions_Id primary key,
+	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
 )

--- a/src/DbUp.Tests/TransactionScenarios.UsingTransactionPerScriptScenarioSuccess.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingTransactionPerScriptScenarioSuccess.approved.txt
@@ -16,7 +16,7 @@ Commit transaction
 Dispose transaction
 Begin transaction
 Execute non query command: create table [SchemaVersions] (
-	[Id] int identity(1,1) not null constraint PK_SchemaVersions_Id primary key,
+	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
 )
@@ -44,7 +44,7 @@ Commit transaction
 Dispose transaction
 Begin transaction
 Execute non query command: create table [SchemaVersions] (
-	[Id] int identity(1,1) not null constraint PK_SchemaVersions_Id primary key,
+	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
 )

--- a/src/DbUp/Support/Firebird/FirebirdTableJournal.cs
+++ b/src/DbUp/Support/Firebird/FirebirdTableJournal.cs
@@ -38,7 +38,7 @@ namespace DbUp.Support.Firebird
                                         schemaversionsid INTEGER NOT NULL,
                                         scriptname VARCHAR(255) NOT NULL,
                                         applied TIMESTAMP NOT NULL,
-                                        CONSTRAINT pk_schemaversions_id PRIMARY KEY (schemaversionsid)
+                                        CONSTRAINT pk_{0}_id PRIMARY KEY (schemaversionsid)
                                     )", tableName);
         }
 

--- a/src/DbUp/Support/Postgresql/PostgresqlTableJournal.cs
+++ b/src/DbUp/Support/Postgresql/PostgresqlTableJournal.cs
@@ -1,10 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
 using DbUp.Engine;
 using DbUp.Engine.Output;
 using DbUp.Engine.Transactions;
-using System.Data;
-using System.Data.Common;
-using System.Collections.Generic;
 
 namespace DbUp.Support.Postgresql
 {
@@ -14,7 +14,8 @@ namespace DbUp.Support.Postgresql
     /// </summary>
     public sealed class PostgresqlTableJournal : IJournal
     {
-        private readonly string schemaTableName;
+        private readonly string schema;
+        private readonly string table;
         private readonly Func<IConnectionManager> connectionManager;
         private readonly Func<IUpgradeLog> log;
 
@@ -32,23 +33,24 @@ namespace DbUp.Support.Postgresql
         /// <param name="table">The name of the journal table.</param>
         public PostgresqlTableJournal(Func<IConnectionManager> connectionManager, Func<IUpgradeLog> logger, string schema, string table)
         {
-            schemaTableName = string.IsNullOrEmpty(schema)
-                ? QuoteIdentifier(table)
-                : QuoteIdentifier(schema) + "." + QuoteIdentifier(table);
+            this.schema = schema;
+            this.table = table;
             this.connectionManager = connectionManager;
-            log = logger;        
+            log = logger;
         }
 
-        private static string CreateTableSql(string tableName)
+        private static string CreateTableSql(string schema, string table)
         {
+            var tableName = CreateTableName(schema, table);
+            var primaryKeyName = CreatePrimaryKeyName(schema, table);
             return string.Format(
                             @"CREATE TABLE {0}
                               (
                                 schemaversionsid serial NOT NULL,
                                 scriptname character varying(255) NOT NULL,
                                 applied timestamp without time zone NOT NULL,
-                                CONSTRAINT pk_schemaversions_id PRIMARY KEY (schemaversionsid)
-                              )", tableName);
+                                CONSTRAINT {1} PRIMARY KEY (schemaversionsid)
+                              )", tableName, primaryKeyName);
         }
 
         public string[] GetExecutedScripts()
@@ -57,7 +59,7 @@ namespace DbUp.Support.Postgresql
             var exists = DoesTableExist();
             if (!exists)
             {
-                log().WriteInformation(string.Format("The {0} table could not be found. The database is assumed to be at version 0.", schemaTableName));
+                log().WriteInformation(string.Format("The {0} table could not be found. The database is assumed to be at version 0.", CreateTableName(schema, table)));
                 return new string[0];
             }
 
@@ -66,7 +68,7 @@ namespace DbUp.Support.Postgresql
             {
                 using (var command = dbCommandFactory())
                 {
-                    command.CommandText = GetExecutedScriptsSql(schemaTableName);
+                    command.CommandText = GetExecutedScriptsSql(schema, table);
                     command.CommandType = CommandType.Text;
 
                     using (var reader = command.ExecuteReader())
@@ -89,19 +91,19 @@ namespace DbUp.Support.Postgresql
             var exists = DoesTableExist();
             if (!exists)
             {
-                log().WriteInformation(string.Format("Creating the {0} table", schemaTableName));
+                log().WriteInformation(string.Format("Creating the {0} table", CreateTableName(schema, table)));
 
                 connectionManager().ExecuteCommandsWithManagedConnection(dbCommandFactory =>
                 {
                     using (var command = dbCommandFactory())
                     {
-                        command.CommandText = CreateTableSql(schemaTableName);
+                        command.CommandText = CreateTableSql(schema, table);
 
                         command.CommandType = CommandType.Text;
                         command.ExecuteNonQuery();
                     }
 
-                    log().WriteInformation(string.Format("The {0} table has been created", schemaTableName));
+                    log().WriteInformation(string.Format("The {0} table has been created", CreateTableName(schema, table)));
                 });
             }
 
@@ -109,7 +111,7 @@ namespace DbUp.Support.Postgresql
             {
                 using (var command = dbCommandFactory())
                 {
-                    command.CommandText = string.Format("insert into {0} (ScriptName, Applied) values (@scriptName, @applied)", schemaTableName);
+                    command.CommandText = string.Format("insert into {0} (ScriptName, Applied) values (@scriptName, @applied)", CreateTableName(schema, table));
 
                     var scriptNameParam = command.CreateParameter();
                     scriptNameParam.ParameterName = "scriptName";
@@ -127,9 +129,22 @@ namespace DbUp.Support.Postgresql
             });
         }
 
-        private static string GetExecutedScriptsSql(string table)
+        private static string GetExecutedScriptsSql(string schema, string table)
         {
-            return string.Format("select ScriptName from {0} order by ScriptName", table);
+            var tableName = CreateTableName(schema, table);
+            return string.Format("select ScriptName from {0} order by ScriptName", tableName);
+        }
+
+        private static string CreateTableName(string schema, string table)
+        {
+            return string.IsNullOrEmpty(schema)
+                ? QuoteIdentifier(table)
+                : QuoteIdentifier(schema) + "." + QuoteIdentifier(table);
+        }
+
+        private static string CreatePrimaryKeyName(string schema, string table)
+        {
+            return QuoteIdentifier("PK_" + table + "_Id");
         }
 
         private bool DoesTableExist()
@@ -140,7 +155,7 @@ namespace DbUp.Support.Postgresql
                 {
                     using (var command = dbCommandFactory())
                     {
-                        command.CommandText = string.Format("select count(*) from {0}", schemaTableName);
+                        command.CommandText = string.Format("select count(*) from {0}", CreateTableName(schema, table));
                         command.CommandType = CommandType.Text;
                         command.ExecuteScalar();
                         return true;

--- a/src/DbUp/Support/SqlServer/SqlTableJournal.cs
+++ b/src/DbUp/Support/SqlServer/SqlTableJournal.cs
@@ -15,9 +15,10 @@ namespace DbUp.Support.SqlServer
     /// </summary>
     public class SqlTableJournal : IJournal
     {
-        private readonly string schemaTableName;
         private readonly Func<IConnectionManager> connectionManager;
         private readonly Func<IUpgradeLog> log;
+        private readonly string schema;
+        private readonly string table;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlTableJournal"/> class.
@@ -31,10 +32,11 @@ namespace DbUp.Support.SqlServer
         /// </example>
         public SqlTableJournal(Func<IConnectionManager> connectionManager, Func<IUpgradeLog> logger, string schema, string table)
         {
-            schemaTableName = string.IsNullOrEmpty(schema) 
-                ? SqlObjectParser.QuoteSqlObjectName(table)
-                : SqlObjectParser.QuoteSqlObjectName(schema) + "." + SqlObjectParser.QuoteSqlObjectName(table);
+            this.schema = schema;
+            this.table = table;
+
             this.connectionManager = connectionManager;
+
             log = logger;
         }
 
@@ -48,7 +50,7 @@ namespace DbUp.Support.SqlServer
             var exists = DoesTableExist();
             if (!exists)
             {
-                log().WriteInformation(string.Format("The {0} table could not be found. The database is assumed to be at version 0.", schemaTableName));
+                log().WriteInformation(string.Format("The {0} table could not be found. The database is assumed to be at version 0.", CreateTableName(schema, table)));
                 return new string[0];
             }
 
@@ -57,7 +59,7 @@ namespace DbUp.Support.SqlServer
             {
                 using (var command = dbCommandFactory())
                 {
-                    command.CommandText = GetExecutedScriptsSql(schemaTableName);
+                    command.CommandText = GetExecutedScriptsSql(schema, table);
                     command.CommandType = CommandType.Text;
 
                     using (var reader = command.ExecuteReader())
@@ -72,11 +74,11 @@ namespace DbUp.Support.SqlServer
         }
 
         /// <summary>
-        /// The Sql which gets 
+        /// Create an SQL statement which will retrieve all executed scripts in order.
         /// </summary>
-        protected virtual string GetExecutedScriptsSql(string table)
+        protected virtual string GetExecutedScriptsSql(string schema, string table)
         {
-            return string.Format("select [ScriptName] from {0} order by [ScriptName]", table);
+            return string.Format("select [ScriptName] from {0} order by [ScriptName]", CreateTableName(schema, table));
         }
 
         /// <summary>
@@ -88,19 +90,19 @@ namespace DbUp.Support.SqlServer
             var exists = DoesTableExist();
             if (!exists)
             {
-                log().WriteInformation(string.Format("Creating the {0} table", schemaTableName));
+                log().WriteInformation(string.Format("Creating the {0} table", CreateTableName(schema, table)));
 
                 connectionManager().ExecuteCommandsWithManagedConnection(dbCommandFactory =>
                 {
                     using (var command = dbCommandFactory())
                     {
-                        command.CommandText = CreateTableSql(schemaTableName);
+                        command.CommandText = CreateTableSql(schema, table);
 
                         command.CommandType = CommandType.Text;
                         command.ExecuteNonQuery();
                     }
 
-                    log().WriteInformation(string.Format("The {0} table has been created", schemaTableName));
+                    log().WriteInformation(string.Format("The {0} table has been created", CreateTableName(schema, table)));
                 });
             }
 
@@ -108,7 +110,7 @@ namespace DbUp.Support.SqlServer
             {
                 using (var command = dbCommandFactory())
                 {
-                    command.CommandText = string.Format("insert into {0} (ScriptName, Applied) values (@scriptName, @applied)", schemaTableName);
+                    command.CommandText = string.Format("insert into {0} (ScriptName, Applied) values (@scriptName, @applied)", CreateTableName(schema, table));
 
                     var scriptNameParam = command.CreateParameter();
                     scriptNameParam.ParameterName = "scriptName";
@@ -126,18 +128,42 @@ namespace DbUp.Support.SqlServer
             });
         }
 
-        /// <summary>
-        /// The sql to exectute to create the schema versions table
-        /// </summary>
-        /// <param name="tableName"></param>
-        /// <returns></returns>
-        protected virtual string CreateTableSql(string tableName)
+        /// <summary>Generates an SQL statement that, when exectuted, will create the journal database table.</summary>
+        /// <param name="schema">Desired schema name supplied by configuration or <c>NULL</c></param>
+        /// <param name="table">Desired table name</param>
+        /// <returns>A <c>CREATE TABLE</c> SQL statement</returns>
+        protected virtual string CreateTableSql(string schema, string table)
         {
+            var tableName = CreateTableName(schema, table);
+            var primaryKeyConstraintName = CreatePrimaryKeyName(schema, table);
+
             return string.Format(@"create table {0} (
-	[Id] int identity(1,1) not null constraint PK_SchemaVersions_Id primary key,
+	[Id] int identity(1,1) not null constraint {1} primary key,
 	[ScriptName] nvarchar(255) not null,
 	[Applied] datetime not null
-)", tableName);
+)", tableName, primaryKeyConstraintName);
+        }
+
+        /// <summary>Combine the <c>schema</c> and <c>table</c> values into an appropriately-quoted identifier for the journal table.</summary>
+        /// <param name="schema">Desired schema name supplied by configuration or <c>NULL</c></param>
+        /// <param name="table">Desired table name</param>
+        /// <returns>Quoted journal table identifier</returns>
+        protected virtual string CreateTableName(string schema, string table)
+        {
+            return string.IsNullOrEmpty(schema)
+                ? SqlObjectParser.QuoteSqlObjectName(table)
+                : SqlObjectParser.QuoteSqlObjectName(schema) + "." + SqlObjectParser.QuoteSqlObjectName(table);
+        }
+
+        /// <summary>Combine the <c>schema</c> and <c>table</c> values into an appropriately-quoted identifier for the journal table's unique primary key.</summary>
+        /// <param name="schema">Desired schema name supplied by configuration or <c>NULL</c></param>
+        /// <param name="table">Desired table name</param>
+        /// <returns>Quoted journal table primary key identifier</returns>
+        protected virtual string CreatePrimaryKeyName(string schema, string table)
+        {
+            return string.IsNullOrEmpty(schema)
+                ? SqlObjectParser.QuoteSqlObjectName("PK_" + table + "_Id")
+                : SqlObjectParser.QuoteSqlObjectName(schema) + "." + SqlObjectParser.QuoteSqlObjectName("PK_" + table + "_Id");
         }
 
         private bool DoesTableExist()
@@ -148,7 +174,7 @@ namespace DbUp.Support.SqlServer
                 {
                     using (var command = dbCommandFactory())
                     {
-                        command.CommandText = string.Format("select count(*) from {0}", schemaTableName);
+                        command.CommandText = string.Format("select count(*) from {0}", CreateTableName(schema, table));
                         command.CommandType = CommandType.Text;
                         command.ExecuteScalar();
                         return true;

--- a/src/DbUp/Support/SqlServer/SqlTableJournal.cs
+++ b/src/DbUp/Support/SqlServer/SqlTableJournal.cs
@@ -135,7 +135,7 @@ namespace DbUp.Support.SqlServer
         protected virtual string CreateTableSql(string schema, string table)
         {
             var tableName = CreateTableName(schema, table);
-            var primaryKeyConstraintName = CreatePrimaryKeyName(schema, table);
+            var primaryKeyConstraintName = CreatePrimaryKeyName(table);
 
             return string.Format(@"create table {0} (
 	[Id] int identity(1,1) not null constraint {1} primary key,
@@ -155,15 +155,12 @@ namespace DbUp.Support.SqlServer
                 : SqlObjectParser.QuoteSqlObjectName(schema) + "." + SqlObjectParser.QuoteSqlObjectName(table);
         }
 
-        /// <summary>Combine the <c>schema</c> and <c>table</c> values into an appropriately-quoted identifier for the journal table's unique primary key.</summary>
-        /// <param name="schema">Desired schema name supplied by configuration or <c>NULL</c></param>
+        /// <summary>Convert the <c>table</c> value into an appropriately-quoted identifier for the journal table's unique primary key.</summary>
         /// <param name="table">Desired table name</param>
         /// <returns>Quoted journal table primary key identifier</returns>
-        protected virtual string CreatePrimaryKeyName(string schema, string table)
+        protected virtual string CreatePrimaryKeyName(string table)
         {
-            return string.IsNullOrEmpty(schema)
-                ? SqlObjectParser.QuoteSqlObjectName("PK_" + table + "_Id")
-                : SqlObjectParser.QuoteSqlObjectName(schema) + "." + SqlObjectParser.QuoteSqlObjectName("PK_" + table + "_Id");
+            return SqlObjectParser.QuoteSqlObjectName("PK_" + table + "_Id");
         }
 
         private bool DoesTableExist()

--- a/src/DbUp/Support/Sqlite/SqliteTableJournal.cs
+++ b/src/DbUp/Support/Sqlite/SqliteTableJournal.cs
@@ -26,7 +26,7 @@ namespace DbUp.Support.SQLite
         protected override string CreateTableSql(string schema, string table)
         {
             var tableName = CreateTableName(null, table);
-            var primaryKeyName = CreatePrimaryKeyName(null, table);
+            var primaryKeyName = CreatePrimaryKeyName(table);
             return string.Format(
                             @"CREATE TABLE {0} (
 	SchemaVersionID INTEGER CONSTRAINT {1} PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -35,11 +35,10 @@ namespace DbUp.Support.SQLite
 )", tableName, primaryKeyName);
         }
 
-        /// <summary>Combine the <c>schema</c> and <c>table</c> values into an appropriately-quoted identifier for the journal table's unique primary key.</summary>
-        /// <param name="schema">This parameter is ignored as SQLLite doesn't have schemas.</param>
+        /// <summary>Convert the <c>table</c> value into an appropriately-quoted identifier for the journal table's unique primary key.</summary>
         /// <param name="table">Desired table name</param>
         /// <returns>Quoted journal table primary key identifier</returns>
-        protected override string CreatePrimaryKeyName(string schema, string table)
+        protected override string CreatePrimaryKeyName(string table)
         {
             return "'PK_" + table + "_SchemaVersionID'";
         }

--- a/src/DbUp/Support/Sqlite/SqliteTableJournal.cs
+++ b/src/DbUp/Support/Sqlite/SqliteTableJournal.cs
@@ -19,19 +19,29 @@ namespace DbUp.Support.SQLite
             base(connectionManager, logger, null, table)
         {}
 
-        /// <summary>
-        /// Create table sql for SQLite
-        /// </summary>
-        /// <param name="tableName"></param>
-        /// <returns></returns>
-        protected override string CreateTableSql(string tableName)
+        /// <summary>Generates an SQL statement that, when exectuted, will create the journal database table.</summary>
+        /// <param name="schema">This parameter is ignored as SQLLite doesn't have schemas.</param>
+        /// <param name="table">Desired table name</param>
+        /// <returns>A <c>CREATE TABLE</c> SQL statement</returns>
+        protected override string CreateTableSql(string schema, string table)
         {
+            var tableName = CreateTableName(null, table);
+            var primaryKeyName = CreatePrimaryKeyName(null, table);
             return string.Format(
                             @"CREATE TABLE {0} (
-	SchemaVersionID INTEGER CONSTRAINT 'PK_SchemaVersions_SchemaVersionID' PRIMARY KEY AUTOINCREMENT NOT NULL,
+	SchemaVersionID INTEGER CONSTRAINT {1} PRIMARY KEY AUTOINCREMENT NOT NULL,
 	ScriptName TEXT NOT NULL,
 	Applied DATETIME NOT NULL
-)", tableName);
+)", tableName, primaryKeyName);
+        }
+
+        /// <summary>Combine the <c>schema</c> and <c>table</c> values into an appropriately-quoted identifier for the journal table's unique primary key.</summary>
+        /// <param name="schema">This parameter is ignored as SQLLite doesn't have schemas.</param>
+        /// <param name="table">Desired table name</param>
+        /// <returns>Quoted journal table primary key identifier</returns>
+        protected override string CreatePrimaryKeyName(string schema, string table)
+        {
+            return "'PK_" + table + "_SchemaVersionID'";
         }
     }
 }


### PR DESCRIPTION
Changes the "CREATE TABLE" scripts to ensure that named primary key constraints include the given table name. Avoiding name collisions if two differently-named journal tables are created within a single database.

Impacts the following Journals:
 - SQL Server and SQL CE
 - PostgreSQL
 - Firebird

Fixes #146