### PR TITLE
Remove reliance on exceptions to check if table exists (fixes #142)

### DIFF
--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SQLite.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SQLite.approved.txt
@@ -1,9 +1,9 @@
 ﻿Open connection
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'SchemaVersions' COLLATE NOCASE
 Dispose command
 Execute non query command: script1contents
 Dispose command
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'SchemaVersions' COLLATE NOCASE
 Dispose command
 Execute non query command: CREATE TABLE [SchemaVersions] (
 	SchemaVersionID INTEGER CONSTRAINT 'PK_SchemaVersions_SchemaVersionID' PRIMARY KEY AUTOINCREMENT NOT NULL,

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SqlCe.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SqlCe.approved.txt
@@ -1,9 +1,9 @@
 ﻿Open connection
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: script1contents
 Dispose command
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: create table [SchemaVersions] (
 	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SqlServer.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SqlServer.approved.txt
@@ -1,9 +1,9 @@
 ﻿Open connection
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: script1contents
 Dispose command
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: create table [SchemaVersions] (
 	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SQLite.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SQLite.approved.txt
@@ -1,9 +1,9 @@
 ﻿Open connection
-Execute scalar command: select count(*) from [TestSchemaVersions]
+Execute scalar command: SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'TestSchemaVersions' COLLATE NOCASE
 Dispose command
 Execute non query command: script1contents
 Dispose command
-Execute scalar command: select count(*) from [TestSchemaVersions]
+Execute scalar command: SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'TestSchemaVersions' COLLATE NOCASE
 Dispose command
 Execute non query command: CREATE TABLE [TestSchemaVersions] (
 	SchemaVersionID INTEGER CONSTRAINT 'PK_TestSchemaVersions_SchemaVersionID' PRIMARY KEY AUTOINCREMENT NOT NULL,

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlCe.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlCe.approved.txt
@@ -1,9 +1,9 @@
 ﻿Open connection
-Execute scalar command: select count(*) from [test].[TestSchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'TestSchemaVersions' and TABLE_SCHEMA = 'test'
 Dispose command
 Execute non query command: script1contents
 Dispose command
-Execute scalar command: select count(*) from [test].[TestSchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'TestSchemaVersions' and TABLE_SCHEMA = 'test'
 Dispose command
 Execute non query command: create table [test].[TestSchemaVersions] (
 	[Id] int identity(1,1) not null constraint [PK_TestSchemaVersions_Id] primary key,

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlServer.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlServer.approved.txt
@@ -1,9 +1,9 @@
 ﻿Open connection
-Execute scalar command: select count(*) from [test].[TestSchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'TestSchemaVersions' and TABLE_SCHEMA = 'test'
 Dispose command
 Execute non query command: script1contents
 Dispose command
-Execute scalar command: select count(*) from [test].[TestSchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'TestSchemaVersions' and TABLE_SCHEMA = 'test'
 Dispose command
 Execute non query command: create table [test].[TestSchemaVersions] (
 	[Id] int identity(1,1) not null constraint [PK_TestSchemaVersions_Id] primary key,

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SQLite.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SQLite.approved.txt
@@ -1,9 +1,9 @@
 ﻿Open connection
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'SchemaVersions' COLLATE NOCASE
 Dispose command
 Execute non query command: print SubstitutedValue
 Dispose command
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'SchemaVersions' COLLATE NOCASE
 Dispose command
 Execute non query command: CREATE TABLE [SchemaVersions] (
 	SchemaVersionID INTEGER CONSTRAINT 'PK_SchemaVersions_SchemaVersionID' PRIMARY KEY AUTOINCREMENT NOT NULL,

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SqlCe.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SqlCe.approved.txt
@@ -1,9 +1,9 @@
 ﻿Open connection
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: print SubstitutedValue
 Dispose command
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: create table [SchemaVersions] (
 	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SqlServer.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SqlServer.approved.txt
@@ -1,9 +1,9 @@
 ﻿Open connection
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: print SubstitutedValue
 Dispose command
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: create table [SchemaVersions] (
 	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,

--- a/src/DbUp.Tests/DbUp.approved.cs
+++ b/src/DbUp.Tests/DbUp.approved.cs
@@ -327,6 +327,7 @@ namespace DbUp.Support.SQLite
         public SQLiteTableJournal(System.Func<DbUp.Engine.Transactions.IConnectionManager> connectionManager, System.Func<DbUp.Engine.Output.IUpgradeLog> logger, string table) { }
         protected override string CreatePrimaryKeyName(string table) { }
         protected override string CreateTableSql(string schema, string table) { }
+        protected override bool VerifyTableExistsCommand(System.Data.IDbCommand command, string tableName, string schemaName) { }
     }
 }
 namespace DbUp.Support.SqlServer
@@ -394,6 +395,7 @@ namespace DbUp.Support.SqlServer
         public string[] GetExecutedScripts() { }
         protected virtual string GetExecutedScriptsSql(string schema, string table) { }
         public void StoreExecutedScript(DbUp.Engine.SqlScript script) { }
+        protected virtual bool VerifyTableExistsCommand(System.Data.IDbCommand command, string tableName, string schemaName) { }
     }
 }
 

--- a/src/DbUp.Tests/TransactionScenarios.UsingNoTransactionsScenario.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingNoTransactionsScenario.approved.txt
@@ -1,9 +1,9 @@
 ﻿Open connection
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: print 'script1'
 Dispose command
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: create table [SchemaVersions] (
 	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,
@@ -19,7 +19,7 @@ Execute non query command: insert into [SchemaVersions] (ScriptName, Applied) va
 Dispose command
 Execute non query command: print 'script2'
 Dispose command
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: create table [SchemaVersions] (
 	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,

--- a/src/DbUp.Tests/TransactionScenarios.UsingNoTransactionsScenarioScriptFails.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingNoTransactionsScenarioScriptFails.approved.txt
@@ -1,5 +1,5 @@
 ﻿Open connection
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: error
 Dispose command

--- a/src/DbUp.Tests/TransactionScenarios.UsingSingleTransactionScenarioSuccess.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingSingleTransactionScenarioSuccess.approved.txt
@@ -1,10 +1,10 @@
 ﻿Open connection
 Begin transaction
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: print 'script1'
 Dispose command
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: create table [SchemaVersions] (
 	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,
@@ -20,7 +20,7 @@ Execute non query command: insert into [SchemaVersions] (ScriptName, Applied) va
 Dispose command
 Execute non query command: print 'script2'
 Dispose command
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: create table [SchemaVersions] (
 	[Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,

--- a/src/DbUp.Tests/TransactionScenarios.UsingSingleTransactionScenarioSuccessScriptFails.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingSingleTransactionScenarioSuccessScriptFails.approved.txt
@@ -1,6 +1,6 @@
 ﻿Open connection
 Begin transaction
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Execute non query command: error
 Dispose command

--- a/src/DbUp.Tests/TransactionScenarios.UsingTransactionPerScriptScenarioScriptFails.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingTransactionPerScriptScenarioScriptFails.approved.txt
@@ -1,6 +1,6 @@
 ﻿Open connection
 Begin transaction
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Commit transaction
 Dispose transaction

--- a/src/DbUp.Tests/TransactionScenarios.UsingTransactionPerScriptScenarioSuccess.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingTransactionPerScriptScenarioSuccess.approved.txt
@@ -1,6 +1,6 @@
 ﻿Open connection
 Begin transaction
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Commit transaction
 Dispose transaction
@@ -10,7 +10,7 @@ Dispose command
 Commit transaction
 Dispose transaction
 Begin transaction
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Commit transaction
 Dispose transaction
@@ -38,7 +38,7 @@ Dispose command
 Commit transaction
 Dispose transaction
 Begin transaction
-Execute scalar command: select count(*) from [SchemaVersions]
+Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
 Dispose command
 Commit transaction
 Dispose transaction

--- a/src/DbUp/Support/Sqlite/SqliteTableJournal.cs
+++ b/src/DbUp/Support/Sqlite/SqliteTableJournal.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using DbUp.Engine;
 using DbUp.Engine.Output;
 using DbUp.Engine.Transactions;
@@ -41,6 +42,19 @@ namespace DbUp.Support.SQLite
         protected override string CreatePrimaryKeyName(string table)
         {
             return "'PK_" + table + "_SchemaVersionID'";
+        }
+
+        /// <summary>Verify, using database-specific queries, if the table exists in the database.</summary>
+        /// <param name="command">The <c>IDbCommand</c> to be used for the query</param>
+        /// <param name="tableName">The name of the table</param>
+        /// <param name="schemaName">The schema for the table</param>
+        /// <returns>True if table exists, false otherwise</returns>
+        protected override bool VerifyTableExistsCommand(IDbCommand command, string tableName, string schemaName)
+        {
+            command.CommandText = string.Format("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = '{0}' COLLATE NOCASE", tableName);
+            command.CommandType = CommandType.Text;
+            var result = (long)command.ExecuteScalar();
+            return result == 1;
         }
     }
 }


### PR DESCRIPTION
The code that checks if a table exists was relying on doing a `select count(*) from {table}` and expecting an Exception from the database when the table was not there.

It's not clear to me why showing the Exception while debugging, as seen on #142, altered the flow of execution, or how this could be behaving differently in 3.2.1, but since relying on exceptions for flow control is smelly I've implemented db-specific checks for SqlServer and SQLite.

For that I needed to change the public API and the expected log files so this PR grew a lil bit.