### PR TITLE
Not removing Carriage returns when they are followed by End of Line

### DIFF
--- a/src/DbUp.Tests/Support/SqlServer/SqlCommandSplitterTests.cs
+++ b/src/DbUp.Tests/Support/SqlServer/SqlCommandSplitterTests.cs
@@ -124,10 +124,10 @@ SELECT AccountId,
             sqlCommands.ShouldNotBeNull();
             sqlCommands.Length.ShouldBe(4);
 
-            sqlCommands[0].ShouldBe(sqlCommandWithMultiLineComment.Replace("\r\n", "\n").Trim());
-            sqlCommands[1].ShouldBe(sqlCommandWithSingleLineComment.Replace("\r\n", "\n").Trim());
-            sqlCommands[2].ShouldBe(sqlCommandWithSingleLineCommentWithEndDashes.Replace("\r\n", "\n").Trim());
-            sqlCommands[3].ShouldBe(strangeInsert.Replace("\r\n", "\n").Trim());
+            sqlCommands[0].ShouldBe(sqlCommandWithMultiLineComment.Trim());
+            sqlCommands[1].ShouldBe(sqlCommandWithSingleLineComment.Trim());
+            sqlCommands[2].ShouldBe(sqlCommandWithSingleLineCommentWithEndDashes.Trim());
+            sqlCommands[3].ShouldBe(strangeInsert.Trim());
         }
     }
 }

--- a/src/DbUp/Support/SqlServer/SqlCommandReader.cs
+++ b/src/DbUp/Support/SqlServer/SqlCommandReader.cs
@@ -135,8 +135,8 @@ namespace DbUp.Support.SqlServer
                 currentIndex++;
                 LastChar = CurrentChar;
                 CurrentChar = (char)result;
-                // We don't care about Carriage returns, just skip them
-                if (CurrentChar == CarriageReturn)
+                // We don't care about Carriage returns, unless it is followed by End of line
+                if (CurrentChar == CarriageReturn && PeekChar() != EndOfLineChar)
                     return Read();
                 return result;
             }


### PR DESCRIPTION
I encounter an error when altering a stored procedure via DbUp. It was a fairy complicated procedure with some dynamic SQL commands. When alter SQL was executed manually everything was working well. However when same script was invoked by DbUp, syntax error was being thrown.

I found out it was cause by DbUp removal of all Carriage returns.

Changes made in this pull request solved the issue.

I'm not entirely sure what is the root cause of SQL Server behavior when stored procedure has only Line breaks (LF) instead of Carriage returns followed by Line breaks (CR LF)

