### PR TITLE
Fix for running dbup on Azure boxes.

### DIFF
--- a/src/DbUp/Support/SqlServer/SqlServerExtensions.cs
+++ b/src/DbUp/Support/SqlServer/SqlServerExtensions.cs
@@ -185,7 +185,8 @@ public static class SqlServerExtensions
             // Create the database...
             using (var command = new SqlCommand(sqlCommandText, connection)
             {
-                CommandType = CommandType.Text
+                CommandType = CommandType.Text,
+				CommandTimeout = 120
             })
             {
                 command.ExecuteNonQuery();


### PR DESCRIPTION
I could increase the timeout through a configure like the example in this article "https://phejndorf.wordpress.com/2014/07/02/setting-execution-timeout-in-dbup/" but unfortunately this is not possible for EnsureDatabase.For.SqlServer() method.