### PR TITLE
Port of #171 to 4.0.0

### DIFF
--- a/src/DbUp.Core/Support/TableJournal.cs
+++ b/src/DbUp.Core/Support/TableJournal.cs
@@ -206,6 +206,11 @@ namespace DbUp.Support
 
         /// <summary>Verify, using database-specific queries, if the table exists in the database.</summary>
         /// <returns>1 if table exists, 0 otherwise</returns>
-        protected abstract string DoesTableExistSql();
+        protected virtual string DoesTableExistSql()
+        {
+            return string.IsNullOrEmpty(SchemaTableSchema)
+                            ? string.Format("select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '{0}'", UnquotedSchemaTableName)
+                            : string.Format("select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '{0}' and TABLE_SCHEMA = '{1}'", UnquotedSchemaTableName, SchemaTableSchema);
+        }
     }
 }

--- a/src/DbUp.Firebird/FirebirdTableJournal.cs
+++ b/src/DbUp.Firebird/FirebirdTableJournal.cs
@@ -68,7 +68,7 @@ END;";
 
         protected override string DoesTableExistSql()
         {
-            return $"SELECT RDB$RELATION_NAME FROM RDB$RELATIONS WHERE RDB$RELATION_NAME = '{UnquotedSchemaTableName}'";
+            return $"select 1 from RDB$RELATIONS where RDB$SYSTEM_FLAG = 0 and RDB$RELATION_NAME = '{UnquotedSchemaTableName}'";
         }
 
         protected override string GetInsertJournalEntrySql(string @scriptName, string @applied)

--- a/src/DbUp.MySql/MySqlTableJournal.cs
+++ b/src/DbUp.MySql/MySqlTableJournal.cs
@@ -45,13 +45,5 @@ $@"CREATE TABLE {FqSchemaTableName}
     PRIMARY KEY (`schemaversionid`)
 );";
         }
-
-        protected override string DoesTableExistSql()
-        {
-            if (string.IsNullOrEmpty(SchemaTableSchema))
-                return $"SELECT count(TABLE_NAME) FROM information_schema.TABLES WHERE TABLE_NAME='{UnquotedSchemaTableName}'";
-
-            return $"SELECT count(TABLE_NAME) FROM information_schema.TABLES WHERE TABLE_NAME='{UnquotedSchemaTableName}' AND TABLE_SCHEMA='{SchemaTableSchema}'";
-        }
     }
 }

--- a/src/DbUp.Postgresql/PostgresqlTableJournal.cs
+++ b/src/DbUp.Postgresql/PostgresqlTableJournal.cs
@@ -45,13 +45,5 @@ $@"CREATE TABLE {FqSchemaTableName}
     CONSTRAINT {quotedPrimaryKeyName} PRIMARY KEY (schemaversionsid)
 )";
         }
-
-        protected override string DoesTableExistSql()
-        {
-            if (string.IsNullOrEmpty(SchemaTableSchema))
-                return $"SELECT count(*) FROM information_schema.tables WHERE table_name='{UnquotedSchemaTableName}'";
-
-            return $"SELECT count(*) FROM information_schema.tables WHERE table_schema = '{SchemaTableSchema}'AND table_name = '{UnquotedSchemaTableName}')";
-        }
     }
 }

--- a/src/DbUp.SqlServer/SqlTableJournal.cs
+++ b/src/DbUp.SqlServer/SqlTableJournal.cs
@@ -45,13 +45,5 @@ $@"create table {FqSchemaTableName} (
     [Applied] datetime not null
 )";
         }
-
-        protected override string DoesTableExistSql()
-        {
-
-            return string.IsNullOrEmpty(SchemaTableSchema)
-                ? $"select 1 from information_schema.tables where TABLE_NAME = '{UnquotedSchemaTableName}'"
-                : $"select 1 from information_schema.tables where TABLE_NAME = '{UnquotedSchemaTableName}' and TABLE_SCHEMA = '{SchemaTableSchema}'";
-        }
     }
 }

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.Firebird.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.Firebird.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: SELECT RDB$RELATION_NAME FROM RDB$RELATIONS WHERE RDB$RELATION_NAME = 'schemaversions'
+DB Operation: Execute scalar command: select 1 from RDB$RELATIONS where RDB$SYSTEM_FLAG = 0 and RDB$RELATION_NAME = 'schemaversions'
 DB Operation: Dispose command
 Info:         Creating the "schemaversions" table
 DB Operation: Execute non query command: CREATE TABLE "schemaversions"

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.MySql.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.MySql.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: SELECT count(TABLE_NAME) FROM information_schema.TABLES WHERE TABLE_NAME='schemaversions'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'schemaversions'
 DB Operation: Dispose command
 Info:         Creating the `schemaversions` table
 DB Operation: Execute non query command: CREATE TABLE `schemaversions` 

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.PostgreSQL.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.PostgreSQL.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: SELECT count(*) FROM information_schema.tables WHERE table_name='schemaversions'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'schemaversions'
 DB Operation: Dispose command
 Info:         Creating the "schemaversions" table
 DB Operation: Execute non query command: CREATE TABLE "schemaversions"

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SqlServer.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SqlServer.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'SchemaVersions'
 DB Operation: Dispose command
 Info:         Creating the [SchemaVersions] table
 DB Operation: Execute non query command: create table [SchemaVersions] (

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.Firebird.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.Firebird.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: SELECT RDB$RELATION_NAME FROM RDB$RELATIONS WHERE RDB$RELATION_NAME = 'TestSchemaVersions'
+DB Operation: Execute scalar command: select 1 from RDB$RELATIONS where RDB$SYSTEM_FLAG = 0 and RDB$RELATION_NAME = 'TestSchemaVersions'
 DB Operation: Dispose command
 Info:         Creating the "TestSchemaVersions" table
 DB Operation: Execute non query command: CREATE TABLE "TestSchemaVersions"

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.MySql.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.MySql.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: SELECT count(TABLE_NAME) FROM information_schema.TABLES WHERE TABLE_NAME='TestSchemaVersions' AND TABLE_SCHEMA='test'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'TestSchemaVersions' and TABLE_SCHEMA = 'test'
 DB Operation: Dispose command
 Info:         Creating the `test`.`TestSchemaVersions` table
 DB Operation: Execute non query command: CREATE TABLE `test`.`TestSchemaVersions` 

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.PostgreSQL.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.PostgreSQL.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: SELECT count(*) FROM information_schema.tables WHERE table_schema = 'test'AND table_name = 'TestSchemaVersions')
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'TestSchemaVersions' and TABLE_SCHEMA = 'test'
 DB Operation: Dispose command
 Info:         Creating the "test"."TestSchemaVersions" table
 DB Operation: Execute non query command: CREATE TABLE "test"."TestSchemaVersions"

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlCe.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlCe.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'TestSchemaVersions' and TABLE_SCHEMA = 'test'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'TestSchemaVersions' and TABLE_SCHEMA = 'test'
 DB Operation: Dispose command
 Info:         Creating the [test].[TestSchemaVersions] table
 DB Operation: Execute non query command: create table [test].[TestSchemaVersions] (

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlServer.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SqlServer.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'TestSchemaVersions' and TABLE_SCHEMA = 'test'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'TestSchemaVersions' and TABLE_SCHEMA = 'test'
 DB Operation: Dispose command
 Info:         Creating the [test].[TestSchemaVersions] table
 DB Operation: Execute non query command: create table [test].[TestSchemaVersions] (

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.Firebird.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.Firebird.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: SELECT RDB$RELATION_NAME FROM RDB$RELATIONS WHERE RDB$RELATION_NAME = 'schemaversions'
+DB Operation: Execute scalar command: select 1 from RDB$RELATIONS where RDB$SYSTEM_FLAG = 0 and RDB$RELATION_NAME = 'schemaversions'
 DB Operation: Dispose command
 Info:         Creating the "schemaversions" table
 DB Operation: Execute non query command: CREATE TABLE "schemaversions"

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.MySql.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.MySql.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: SELECT count(TABLE_NAME) FROM information_schema.TABLES WHERE TABLE_NAME='schemaversions'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'schemaversions'
 DB Operation: Dispose command
 Info:         Creating the `schemaversions` table
 DB Operation: Execute non query command: CREATE TABLE `schemaversions` 

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.PostgreSQL.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.PostgreSQL.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: SELECT count(*) FROM information_schema.tables WHERE table_name='schemaversions'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'schemaversions'
 DB Operation: Dispose command
 Info:         Creating the "schemaversions" table
 DB Operation: Execute non query command: CREATE TABLE "schemaversions"

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SqlServer.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SqlServer.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'SchemaVersions'
 DB Operation: Dispose command
 Info:         Creating the [SchemaVersions] table
 DB Operation: Execute non query command: create table [SchemaVersions] (

--- a/src/DbUp.Tests/DbUp.MySql.approved.cs
+++ b/src/DbUp.Tests/DbUp.MySql.approved.cs
@@ -41,7 +41,6 @@ namespace DbUp.MySql
     {
         public MySqlTableJournal(System.Func<DbUp.Engine.Transactions.IConnectionManager> connectionManager, System.Func<DbUp.Engine.Output.IUpgradeLog> logger, string schema, string table) { }
         protected override string CreateSchemaTableSql(string quotedPrimaryKeyName) { }
-        protected override string DoesTableExistSql() { }
         protected override string GetInsertJournalEntrySql(string scriptName, string applied) { }
         protected override string GetJournalEntriesSql() { }
     }

--- a/src/DbUp.Tests/DbUp.Postgresql.approved.cs
+++ b/src/DbUp.Tests/DbUp.Postgresql.approved.cs
@@ -31,7 +31,6 @@ namespace DbUp.Postgresql
     {
         public PostgresqlTableJournal(System.Func<DbUp.Engine.Transactions.IConnectionManager> connectionManager, System.Func<DbUp.Engine.Output.IUpgradeLog> logger, string schema, string tableName) { }
         protected override string CreateSchemaTableSql(string quotedPrimaryKeyName) { }
-        protected override string DoesTableExistSql() { }
         protected override string GetInsertJournalEntrySql(string scriptName, string applied) { }
         protected override string GetJournalEntriesSql() { }
     }

--- a/src/DbUp.Tests/DbUp.approved.cs
+++ b/src/DbUp.Tests/DbUp.approved.cs
@@ -345,7 +345,7 @@ namespace DbUp.Support
         protected string UnquotedSchemaTableName { get; }
         protected abstract string CreateSchemaTableSql(string quotedPrimaryKeyName);
         protected bool DoesTableExist() { }
-        protected abstract string DoesTableExistSql();
+        protected virtual string DoesTableExistSql() { }
         protected void EnsureTableIsLatestVersion() { }
         protected System.Data.IDbCommand GetCreateTableCommand(System.Func<System.Data.IDbCommand> dbCommandFactory) { }
         public string[] GetExecutedScripts() { }

--- a/src/DbUp.Tests/Support/MySql/MySqlSupportTests.CanHandleDelimiter.approved.txt
+++ b/src/DbUp.Tests/Support/MySql/MySqlSupportTests.CanHandleDelimiter.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: SELECT count(TABLE_NAME) FROM information_schema.TABLES WHERE TABLE_NAME='schemaversions'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'schemaversions'
 DB Operation: Dispose command
 Info:         Fetching list of already executed scripts.
 DB Operation: Execute reader command: select scriptname from `schemaversions` order by scriptname

--- a/src/DbUp.Tests/TransactionScenarios.UsingNoTransactionsScenario.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingNoTransactionsScenario.approved.txt
@@ -1,7 +1,7 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions' and TABLE_SCHEMA = 'dbo'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'SchemaVersions' and TABLE_SCHEMA = 'dbo'
 DB Operation: Dispose command
 Info:         Creating the [dbo].[SchemaVersions] table
 DB Operation: Execute non query command: create table [dbo].[SchemaVersions] (

--- a/src/DbUp.Tests/TransactionScenarios.UsingNoTransactionsScenarioScriptFails.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingNoTransactionsScenarioScriptFails.approved.txt
@@ -1,5 +1,5 @@
 ﻿DB Operation: Open connection
-DB Operation: Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions' and TABLE_SCHEMA = 'dbo'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'SchemaVersions' and TABLE_SCHEMA = 'dbo'
 DB Operation: Dispose command
 DB Operation: Execute non query command: create table [dbo].[SchemaVersions] (
     [Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,

--- a/src/DbUp.Tests/TransactionScenarios.UsingSingleTransactionScenarioSuccess.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingSingleTransactionScenarioSuccess.approved.txt
@@ -3,7 +3,7 @@ Info:         Beginning transaction
 DB Operation: Begin transaction
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
-DB Operation: Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions' and TABLE_SCHEMA = 'dbo'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'SchemaVersions' and TABLE_SCHEMA = 'dbo'
 DB Operation: Dispose command
 Info:         Creating the [dbo].[SchemaVersions] table
 DB Operation: Execute non query command: create table [dbo].[SchemaVersions] (

--- a/src/DbUp.Tests/TransactionScenarios.UsingSingleTransactionScenarioSuccessScriptFails.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingSingleTransactionScenarioSuccessScriptFails.approved.txt
@@ -1,6 +1,6 @@
 ﻿DB Operation: Open connection
 DB Operation: Begin transaction
-DB Operation: Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions' and TABLE_SCHEMA = 'dbo'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'SchemaVersions' and TABLE_SCHEMA = 'dbo'
 DB Operation: Dispose command
 DB Operation: Execute non query command: create table [dbo].[SchemaVersions] (
     [Id] int identity(1,1) not null constraint [PK_SchemaVersions_Id] primary key,

--- a/src/DbUp.Tests/TransactionScenarios.UsingTransactionPerScriptScenarioScriptFails.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingTransactionPerScriptScenarioScriptFails.approved.txt
@@ -1,6 +1,6 @@
 ﻿DB Operation: Open connection
 DB Operation: Begin transaction
-DB Operation: Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions' and TABLE_SCHEMA = 'dbo'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'SchemaVersions' and TABLE_SCHEMA = 'dbo'
 DB Operation: Dispose command
 DB Operation: Commit transaction
 DB Operation: Dispose transaction

--- a/src/DbUp.Tests/TransactionScenarios.UsingTransactionPerScriptScenarioSuccess.approved.txt
+++ b/src/DbUp.Tests/TransactionScenarios.UsingTransactionPerScriptScenarioSuccess.approved.txt
@@ -2,7 +2,7 @@
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists..
 DB Operation: Begin transaction
-DB Operation: Execute scalar command: select 1 from information_schema.tables where TABLE_NAME = 'SchemaVersions' and TABLE_SCHEMA = 'dbo'
+DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'SchemaVersions' and TABLE_SCHEMA = 'dbo'
 DB Operation: Dispose command
 DB Operation: Commit transaction
 DB Operation: Dispose transaction


### PR DESCRIPTION
Hey @JakeGinnivan, I've ported #171 to 4.0.0, decided to do it in a new PR in a new branch because rebasing blew up, git was saying the files were deleted, it was easier.

Some of the queries were already DB specific, but I thiiink they weren't working.

The base class check for existance like this:

```
var executeScalar = command.ExecuteScalar();
if (executeScalar is long)
    return (long)executeScalar == 1;
return (int)executeScalar == 1;
```

But some of the queries were doing `select TABLE_NAME ...` or `select count(*) ...`and stuff, which would either not return a number or not return `1`.

That OK?

Sorry for the week long delay in porting this, too much work :disappointed: 