### PR TITLE
Changing expected scalar type from int to long for mysql table check

### DIFF
--- a/src/DbUp/Support/MySql/MySqlITableJournal.cs
+++ b/src/DbUp/Support/MySql/MySqlITableJournal.cs
@@ -164,7 +164,7 @@ namespace DbUp.Support.MySql
                             ? string.Format("select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '{0}'", tableName)
                             : string.Format("select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '{0}' and TABLE_SCHEMA = '{1}'", tableName, schemaName);
             command.CommandType = CommandType.Text;
-            var result = command.ExecuteScalar() as int?;
+            var result = command.ExecuteScalar() as long?;
             return result == 1;
         }
     }


### PR DESCRIPTION
Whilst trying to use DbUp for deploying a MySQL database, it consistently failed with more than 1 script. I tracked it down to the query for verifying the existence of the schemaversions table always returning a long. When trying to do an "as" to int? this always returned null, and so the method always returned false.
This meant that if the table already existed, then it would still try and create it again and error.

I had a search around and as far as I can tell this should always return a long, so I have changed the type to a long. This still doesn't fill me with joy as the underlying type _could_ change at any point. Perhaps a "to string" and matching on a string of "1" would overcome this, but fills me with all sorts of other dread.