### PR TITLE
Provide overloads to specify MySql schema to use in extensions

### DIFF
--- a/src/DbUp.MySql/MySqlExtensions.cs
+++ b/src/DbUp.MySql/MySqlExtensions.cs
@@ -28,16 +28,43 @@ public static class MySqlExtensions
     /// <summary>
     /// Creates an upgrader for MySql databases.
     /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">MySql database connection string.</param>
+    /// <param name="schema">Which MySql schema to check for changes</param>
+    /// <returns>
+    /// A builder for a database upgrader designed for MySql databases.
+    /// </returns>
+    public static UpgradeEngineBuilder MySqlDatabase(this SupportedDatabases supported, string connectionString, string schema)
+    {
+        return MySqlDatabase(new MySqlConnectionManager(connectionString), schema);
+    }
+
+    /// <summary>
+    /// Creates an upgrader for MySql databases.
+    /// </summary>
     /// <param name="connectionManager">The <see cref="MySqlConnectionManager"/> to be used during a database upgrade.</param>
     /// <returns>
     /// A builder for a database upgrader designed for MySql databases.
     /// </returns>
     public static UpgradeEngineBuilder MySqlDatabase(IConnectionManager connectionManager)
     {
+        return MySqlDatabase(connectionManager, null);
+    }
+
+    /// <summary>
+    /// Creates an upgrader for MySql databases.
+    /// </summary>
+    /// <param name="connectionManager">The <see cref="MySqlConnectionManager"/> to be used during a database upgrade.</param>
+    /// /// <param name="schema">Which MySQL schema to check for changes</param>
+    /// <returns>
+    /// A builder for a database upgrader designed for MySql databases.
+    /// </returns>
+    public static UpgradeEngineBuilder MySqlDatabase(IConnectionManager connectionManager, string schema)
+    {
         var builder = new UpgradeEngineBuilder();
         builder.Configure(c => c.ConnectionManager = connectionManager);
         builder.Configure(c => c.ScriptExecutor = new SqlScriptExecutor(() => c.ConnectionManager, () => c.Log, null, () => c.VariablesEnabled, c.ScriptPreprocessors));
-        builder.Configure(c => c.Journal = new MySqlITableJournal(() => c.ConnectionManager, () => c.Log, null, "schemaversions"));
+        builder.Configure(c => c.Journal = new MySqlITableJournal(() => c.ConnectionManager, () => c.Log, schema, "schemaversions"));
         builder.WithPreprocessor(new MySqlPreprocessor());
         return builder;
     }

--- a/src/DbUp.Tests/DbUp.MySql.approved.cs
+++ b/src/DbUp.Tests/DbUp.MySql.approved.cs
@@ -31,5 +31,7 @@ namespace DbUp.MySql
 public class static MySqlExtensions
 {
     public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
+    public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
+    public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema) { }
 }


### PR DESCRIPTION
When multiple schemas existed, it checked for any table named schemaversions in any schema.
Query code was already in place to be specific about schema, but not exposed via extensions.