### PR TITLE
Fix for #188 Table '<schemaversions>' doesn't exist

### DIFF
--- a/src/DbUp.MySql/MySqlExtensions.cs
+++ b/src/DbUp.MySql/MySqlExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using DbUp.Builder;
 using System;
+using System.Linq;
 using DbUp;
 using DbUp.MySql;
 using DbUp.Engine.Transactions;
@@ -22,6 +23,11 @@ public static class MySqlExtensions
     /// </returns>
     public static UpgradeEngineBuilder MySqlDatabase(this SupportedDatabases supported, string connectionString)
     {
+        foreach (var pair in connectionString.Split(';').Select(s => s.Split('=')).Where(pair => pair.Length == 2).Where(pair => pair[0].ToLower() == "database"))
+        {
+            return MySqlDatabase(new MySqlConnectionManager(connectionString), pair[1]);
+        }
+
         return MySqlDatabase(new MySqlConnectionManager(connectionString));
     }
 

--- a/src/DbUp/Support/MySql/MySqlITableJournal.cs
+++ b/src/DbUp/Support/MySql/MySqlITableJournal.cs
@@ -160,7 +160,7 @@ namespace DbUp.Support.MySql
         /// <returns>True if table exists, false otherwise</returns>
         private bool VerifyTableExistsCommand(IDbCommand command, string tableName, string schemaName)
         {
-            command.CommandText = string.IsNullOrEmpty(schema)
+            command.CommandText = string.IsNullOrEmpty(schemaName)
                             ? string.Format("select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '{0}'", tableName)
                             : string.Format("select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '{0}' and TABLE_SCHEMA = '{1}'", tableName, schemaName);
             command.CommandType = CommandType.Text;


### PR DESCRIPTION
When deploying to a newly created MySql database, but there are existing databases with schemaversions table created (and you don't explicitly define the name of the database), the VerifiyTableExistsCommand falls back on a SQL query that will return a false result. 

This to avoid this, you needs to ensure that the database name is always defined. If you only pass in a connection string, this doesn't happen. I have thus added some functionaility that if no schema is passed in, then look at the connection string. If it finds a schema name in the connection string use it, else default to the schema name as null