### PR TITLE
Changed default encoding for EmbeddedScriptProvider from ANSI to UTF8

### DIFF
--- a/src/DbUp/ScriptProviders/EmbeddedScriptProvider.cs
+++ b/src/DbUp/ScriptProviders/EmbeddedScriptProvider.cs
@@ -15,7 +15,7 @@ namespace DbUp.ScriptProviders
         /// </summary>
         /// <param name="assembly">The assembly.</param>
         /// <param name="filter">The filter.</param>
-        public EmbeddedScriptProvider(Assembly assembly, Func<string, bool> filter) : this(assembly, filter, Encoding.Default)
+        public EmbeddedScriptProvider(Assembly assembly, Func<string, bool> filter) : this(assembly, filter, Encoding.UTF8)
         {
         }
 


### PR DESCRIPTION
Currently the default encoding for embedded scripts is ANSI. I think this is a bit confusing, as I assumed it was UTF8 - if you try to insert a UTF8 character into a varchar field in your DB it will automatically "convert" it to ANSI - as a result your character is silently corrupted. I suggest this fix.