### PR TITLE
Handle case where executeScalar is null

### DIFF
--- a/src/dbup-core/Support/TableJournal.cs
+++ b/src/dbup-core/Support/TableJournal.cs
@@ -197,6 +197,8 @@ namespace DbUp.Support
                     command.CommandText = DoesTableExistSql();
                     command.CommandType = CommandType.Text;
                     var executeScalar = command.ExecuteScalar();
+                    if (executeScalar == null)
+                        return false;
                     if (executeScalar is long)
                         return (long)executeScalar == 1;
                     return (int)executeScalar == 1;


### PR DESCRIPTION
I have in a few cases experiences that executeScalar is null if I run DbUp agains a empty database (for the first time, meaning there are no SchemaVersions either).