### PR TITLE
#42 Downgrade functionality

### DIFF
--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SQLite.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyBasicSupport.SQLite.approved.txt
@@ -6,7 +6,7 @@ Dispose command
 Execute scalar command: SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'SchemaVersions' COLLATE NOCASE
 Dispose command
 Execute non query command: CREATE TABLE [SchemaVersions] (
-	SchemaVersionID INTEGER CONSTRAINT 'PK_SchemaVersions_SchemaVersionID' PRIMARY KEY AUTOINCREMENT NOT NULL,
+	Id INTEGER CONSTRAINT 'PK_SchemaVersions_SchemaVersionID' PRIMARY KEY AUTOINCREMENT NOT NULL,
 	ScriptName TEXT NOT NULL,
 	Applied DATETIME NOT NULL
 )

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SQLite.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.SQLite.approved.txt
@@ -6,7 +6,7 @@ Dispose command
 Execute scalar command: SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'TestSchemaVersions' COLLATE NOCASE
 Dispose command
 Execute non query command: CREATE TABLE [TestSchemaVersions] (
-	SchemaVersionID INTEGER CONSTRAINT 'PK_TestSchemaVersions_SchemaVersionID' PRIMARY KEY AUTOINCREMENT NOT NULL,
+	Id INTEGER CONSTRAINT 'PK_TestSchemaVersions_SchemaVersionID' PRIMARY KEY AUTOINCREMENT NOT NULL,
 	ScriptName TEXT NOT NULL,
 	Applied DATETIME NOT NULL
 )

--- a/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SQLite.approved.txt
+++ b/src/DbUp.Tests/DatabaseSupportTests.VerifyVariableSubstitutions.SQLite.approved.txt
@@ -6,7 +6,7 @@ Dispose command
 Execute scalar command: SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'SchemaVersions' COLLATE NOCASE
 Dispose command
 Execute non query command: CREATE TABLE [SchemaVersions] (
-	SchemaVersionID INTEGER CONSTRAINT 'PK_SchemaVersions_SchemaVersionID' PRIMARY KEY AUTOINCREMENT NOT NULL,
+	Id INTEGER CONSTRAINT 'PK_SchemaVersions_SchemaVersionID' PRIMARY KEY AUTOINCREMENT NOT NULL,
 	ScriptName TEXT NOT NULL,
 	Applied DATETIME NOT NULL
 )

--- a/src/DbUp.Tests/DbUp.approved.cs
+++ b/src/DbUp.Tests/DbUp.approved.cs
@@ -66,6 +66,7 @@ namespace DbUp.Engine
     public interface IJournal
     {
         string[] GetExecutedScripts();
+        void RemoveExecutedScript(DbUp.Engine.SqlScript script);
         void StoreExecutedScript(DbUp.Engine.SqlScript script);
     }
     public interface IScript
@@ -111,6 +112,7 @@ namespace DbUp.Engine
         public bool IsUpgradeRequired() { }
         public DbUp.Engine.DatabaseUpgradeResult MarkAsExecuted() { }
         public DbUp.Engine.DatabaseUpgradeResult MarkAsExecuted(string latestScript) { }
+        public DbUp.Engine.DatabaseUpgradeResult PerformDowngrade(string scriptToRollback, string rollbackSuffix, bool multipleRollback) { }
         public DbUp.Engine.DatabaseUpgradeResult PerformUpgrade() { }
         public bool TryConnect(out string errorMessage) { }
     }
@@ -240,6 +242,7 @@ namespace DbUp.Helpers
     {
         public NullJournal() { }
         public string[] GetExecutedScripts() { }
+        public void RemoveExecutedScript(DbUp.Engine.SqlScript script) { }
         public void StoreExecutedScript(DbUp.Engine.SqlScript script) { }
     }
     public class TemporarySqlDatabase : System.IDisposable
@@ -302,6 +305,7 @@ namespace DbUp.Support.Firebird
     {
         public FirebirdTableJournal(System.Func<DbUp.Engine.Transactions.IConnectionManager> connectionManager, System.Func<DbUp.Engine.Output.IUpgradeLog> logger, string tableName) { }
         public string[] GetExecutedScripts() { }
+        public void RemoveExecutedScript(DbUp.Engine.SqlScript script) { }
         public void StoreExecutedScript(DbUp.Engine.SqlScript script) { }
     }
 }
@@ -312,6 +316,7 @@ namespace DbUp.Support.MySql
     {
         public MySqlITableJournal(System.Func<DbUp.Engine.Transactions.IConnectionManager> connectionManager, System.Func<DbUp.Engine.Output.IUpgradeLog> logger, string schema, string table) { }
         public string[] GetExecutedScripts() { }
+        public void RemoveExecutedScript(DbUp.Engine.SqlScript script) { }
         public void StoreExecutedScript(DbUp.Engine.SqlScript script) { }
     }
 }
@@ -331,6 +336,7 @@ namespace DbUp.Support.Postgresql
     {
         public PostgresqlTableJournal(System.Func<DbUp.Engine.Transactions.IConnectionManager> connectionManager, System.Func<DbUp.Engine.Output.IUpgradeLog> logger, string schema, string table) { }
         public string[] GetExecutedScripts() { }
+        public void RemoveExecutedScript(DbUp.Engine.SqlScript script) { }
         public void StoreExecutedScript(DbUp.Engine.SqlScript script) { }
     }
 }
@@ -435,6 +441,7 @@ namespace DbUp.Support.SqlServer
         protected virtual string CreateTableSql(string schema, string table) { }
         public string[] GetExecutedScripts() { }
         protected virtual string GetExecutedScriptsSql(string schema, string table) { }
+        public void RemoveExecutedScript(DbUp.Engine.SqlScript script) { }
         public void StoreExecutedScript(DbUp.Engine.SqlScript script) { }
         protected virtual bool VerifyTableExistsCommand(System.Data.IDbCommand command, string tableName, string schemaName) { }
     }

--- a/src/DbUp/Engine/IJournal.cs
+++ b/src/DbUp/Engine/IJournal.cs
@@ -16,5 +16,11 @@
         /// </summary>
         /// <param name="script">The script.</param>
         void StoreExecutedScript(SqlScript script);
+
+        /// <summary>
+        /// Removes the record for the rolled back executed script in the database.
+        /// </summary>
+        /// <param name="script">The executed script that got rolled back.</param>
+        void RemoveExecutedScript(SqlScript script);
     }
 }

--- a/src/DbUp/Helpers/NullJournal.cs
+++ b/src/DbUp/Helpers/NullJournal.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using DbUp.Engine;
+﻿using DbUp.Engine;
 
 namespace DbUp.Helpers
 {
@@ -22,6 +21,13 @@ namespace DbUp.Helpers
         /// </summary>
         /// <param name="script"></param>
         public void StoreExecutedScript(SqlScript script)
+        { }
+
+        /// <summary>
+        /// Does not remove the rolled back script, simply returns
+        /// </summary>
+        /// <param name="script"></param>
+        public void RemoveExecutedScript(SqlScript script)
         { }
     }
 }

--- a/src/DbUp/Support/Firebird/FirebirdTableJournal.cs
+++ b/src/DbUp/Support/Firebird/FirebirdTableJournal.cs
@@ -152,9 +152,32 @@ namespace DbUp.Support.Firebird
             });
         }
 
+        /// <summary>
+        /// Removes the rolled back script from the database specified in a given connection string.
+        /// </summary>
+        /// <param name="script">The script.</param>
+        public void RemoveExecutedScript(SqlScript script)
+        {
+            var exists = DoesTableExist();
+            if (!exists)
+            {
+                return;
+            }
+
+            connectionManager().ExecuteCommandsWithManagedConnection(dbCommandFactory =>
+            {
+                using (var command = dbCommandFactory())
+                {
+                    command.CommandText = string.Format("delete from {0} where ScriptName = '{1}'", tableName, script.Name);
+                    command.CommandType = CommandType.Text;
+                    command.ExecuteNonQuery();
+                }
+            });
+        }
+
         private static string GetExecutedScriptsSql(string table)
         {
-            return string.Format("select ScriptName from {0} order by ScriptName", table);
+            return string.Format("select ScriptName from {0} order by Id", table);
         }
 
         private bool DoesTableExist()

--- a/src/DbUp/Support/MySql/MySqlITableJournal.cs
+++ b/src/DbUp/Support/MySql/MySqlITableJournal.cs
@@ -130,9 +130,32 @@ namespace DbUp.Support.MySql
             });
         }
 
+        /// <summary>
+        /// Removes the rolled back script from the database specified in a given connection string.
+        /// </summary>
+        /// <param name="script">The script.</param>
+        public void RemoveExecutedScript(SqlScript script)
+        {
+            var exists = DoesTableExist();
+            if (!exists)
+            {
+                return;
+            }
+
+            connectionManager().ExecuteCommandsWithManagedConnection(dbCommandFactory =>
+            {
+                using (var command = dbCommandFactory())
+                {
+                    command.CommandText = string.Format("delete from {0} where ScriptName = '{1}'", schemaTableName, script.Name);
+                    command.CommandType = CommandType.Text;
+                    command.ExecuteNonQuery();
+                }
+            });
+        }
+
         private static string GetExecutedScriptsSql(string table)
         {
-            return string.Format("select scriptname from {0} order by scriptname", table);
+            return string.Format("select scriptname from {0} order by id", table);
         }
 
         private bool DoesTableExist()

--- a/src/DbUp/Support/Postgresql/PostgresqlTableJournal.cs
+++ b/src/DbUp/Support/Postgresql/PostgresqlTableJournal.cs
@@ -129,10 +129,33 @@ namespace DbUp.Support.Postgresql
             });
         }
 
+        /// <summary>
+        /// Removes the rolled back script from the database specified in a given connection string.
+        /// </summary>
+        /// <param name="script">The script.</param>
+        public void RemoveExecutedScript(SqlScript script)
+        {
+            var exists = DoesTableExist();
+            if (!exists)
+            {
+                return;
+            }
+
+            connectionManager().ExecuteCommandsWithManagedConnection(dbCommandFactory =>
+            {
+                using (var command = dbCommandFactory())
+                {
+                    command.CommandText = string.Format("delete from {0} where ScriptName = '{1}'", CreateTableName(schema, table), script.Name);
+                    command.CommandType = CommandType.Text;
+                    command.ExecuteNonQuery();
+                }
+            });
+        }
+
         private static string GetExecutedScriptsSql(string schema, string table)
         {
             var tableName = CreateTableName(schema, table);
-            return string.Format("select ScriptName from {0} order by ScriptName", tableName);
+            return string.Format("select ScriptName from {0} order by Id", tableName);
         }
 
         private static string CreateTableName(string schema, string table)

--- a/src/DbUp/Support/Sqlite/SqliteTableJournal.cs
+++ b/src/DbUp/Support/Sqlite/SqliteTableJournal.cs
@@ -30,7 +30,7 @@ namespace DbUp.Support.SQLite
             var primaryKeyName = CreatePrimaryKeyName(table);
             return string.Format(
                             @"CREATE TABLE {0} (
-	SchemaVersionID INTEGER CONSTRAINT {1} PRIMARY KEY AUTOINCREMENT NOT NULL,
+	Id INTEGER CONSTRAINT {1} PRIMARY KEY AUTOINCREMENT NOT NULL,
 	ScriptName TEXT NOT NULL,
 	Applied DATETIME NOT NULL
 )", tableName, primaryKeyName);

--- a/src/DbUp/dbup.nuspec
+++ b/src/DbUp/dbup.nuspec
@@ -5,7 +5,7 @@
     <title>DbUp</title>
     <version>$version$</version> 
     <authors>Paul Stovell, Jim Burger, Jake Ginnivan, Damian Maclennan</authors>
-    <description>DbUp makes it easy to deploy and upgrade SQL Server databases by running change scripts.</description> 
+    <description>DbUp makes it easy to deploy and upgrade or rollback and downgrade SQL Server databases by running change scripts.</description> 
     <language>en-US</language>
     <licenseUrl>http://www.opensource.org/licenses/mit-license.php</licenseUrl>
     <releaseNotes>https://github.com/DbUp/DbUp/releases</releaseNotes>


### PR DESCRIPTION
Added support for two forms of rollback

1. Rollback a specific executed script
2. Multiple rollback where you can specify the executed script to roll back to excluding the specified script itself. I.e. if I executed scripts A, B, C and D in that order and I specify to rollback to B then script C and D will be rolled back.

It uses naming convention to find the rollback scripts. E.g. if the rollback suffix is "_rollback" and the executed script name is "test.sql" then the rollback script should be "test_rollback.sql"

Also fixed bug with incorrect column name in SQLiteTableJournal where it had "SchemaVersionID" instead of "Id"