### PR TITLE
Fix issues with formatting exceptions.

### DIFF
--- a/src/DbUp.Tests/UpgradeDatabaseScenarios.cs
+++ b/src/DbUp.Tests/UpgradeDatabaseScenarios.cs
@@ -118,7 +118,7 @@ namespace DbUp.Tests
                 "SQL logic error or missing database\r\n" +
                 "near \"slect\": syntax error");
 
-            log.Received().WriteError(Arg.Is<string>(s => s.StartsWith("System.Data.SQLite.SQLiteException (0x80004005): SQL logic error or missing database")));
+            log.Received().WriteError("{0}", Arg.Is<string>(s => s.StartsWith("System.Data.SQLite.SQLiteException (0x80004005): SQL logic error or missing database")));
             log.Received().WriteError(
                 Arg.Is<string>(s => s.StartsWith("Upgrade failed due to an unexpected exception:")),
                 Arg.Is<string>(s => s.Contains("System.Data.SQLite.SQLiteException")));

--- a/src/DbUp/Support/SqlServer/SqlConnectionManager.cs
+++ b/src/DbUp/Support/SqlServer/SqlConnectionManager.cs
@@ -20,7 +20,7 @@ namespace DbUp.Support.SqlServer
                 var conn = new SqlConnection(connectionString);
 
                 if (dbManager.IsScriptOutputLogged)
-                    conn.InfoMessage += (sender, e) => log.WriteInformation(e.Message + "\r\n");
+                    conn.InfoMessage += (sender, e) => log.WriteInformation("{0}\r\n", e.Message);
 
                 return conn;
             }))

--- a/src/DbUp/Support/SqlServer/SqlScriptExecutor.cs
+++ b/src/DbUp/Support/SqlServer/SqlScriptExecutor.cs
@@ -131,21 +131,21 @@ namespace DbUp.Support.SqlServer
             catch (SqlException sqlException)
             {
                 log().WriteInformation("SQL exception has occured in script: '{0}'", script.Name);
-                log().WriteError("Script block number: {0}; Block line {1}; Message: {2}", index, sqlException.LineNumber, sqlException.Procedure, sqlException.Number, sqlException.Message);
-                log().WriteError(sqlException.ToString());
+                log().WriteError("Script block number: {0}; Block line {1}; Procedure: {2}; Message Number: {3}; Message: {4}", index, sqlException.LineNumber, sqlException.Procedure, sqlException.Number, sqlException.Message);
+                log().WriteError("{0}", sqlException.ToString());
                 throw;
             }
             catch (DbException sqlException)
             {
                 log().WriteInformation("DB exception has occured in script: '{0}'", script.Name);
                 log().WriteError("Script block number: {0}; Error code {1}; Message: {2}", index, sqlException.ErrorCode, sqlException.Message);
-                log().WriteError(sqlException.ToString());
+                log().WriteError("{0}", sqlException.ToString());
                 throw;
             }
             catch (Exception ex)
             {
                 log().WriteInformation("Exception has occured in script: '{0}'", script.Name);
-                log().WriteError(ex.ToString());
+                log().WriteError("{0}", ex.ToString());
                 throw;
             }
         }


### PR DESCRIPTION
Fixed issues with exception logging:
1. When a message containing curly braces is raised by the DB.
2. When a SqlException is thrown, the format parameters did not match the actual parameters.

Addresses issues found in #227 
