### PR TITLE
Adding support for Azure SQL Database Creation Edition

### DIFF
--- a/src/DbUp/DbUp.csproj
+++ b/src/DbUp/DbUp.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Support\Firebird\FirebirdTableJournal.cs" />
     <Compile Include="Support\MySql\MySqlITableJournal.cs" />
     <Compile Include="Support\Postgresql\PostgresqlTableJournal.cs" />
+    <Compile Include="Support\SqlServer\AzureDatabaseEdition.cs" />
     <Compile Include="Support\SqlServer\SqlCommandSplitter.cs" />
     <Compile Include="Support\SqlServer\SqlConnectionManager.cs" />
     <Compile Include="Helpers\AdHocSqlRunner.cs" />

--- a/src/DbUp/Support/SqlServer/AzureDatabaseEdition.cs
+++ b/src/DbUp/Support/SqlServer/AzureDatabaseEdition.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+namespace DbUp.Support.SqlServer
+{
+    /// <summary>
+    /// Azure SQL Insance Edition for Database Creation
+    /// </summary>
+    public enum AzureDatabaseEdition
+    {
+        /// <summary>
+        /// Not an Azure SQL Insance
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Basic Azure SQL Insance
+        /// </summary>
+        Basic,
+        /// <summary>
+        /// Standard Azure SQL Insance
+        /// </summary>
+        Standard,
+        /// <summary>
+        /// Premium Azure SQL Insance
+        /// </summary>
+        Premium
+    }
+}


### PR DESCRIPTION
Adding support to provide the Azure Edition to the EnsureDatabase extension.

Azure has some extra parameters.  We usually run a local SQL Server Instance on build and development machines.  I leaned toward including Azure in the existing SQLServer extension rather than have a separate AzureSqlServerExtension.  I could see a case for a separate one that enables more Azure specific abilities but for simple database creation I liked the simplicity.
