### PR TITLE
Revert "Removed exception handlers from the `DoesTableExist` method"

### DIFF
--- a/src/DbUp.Tests/Support/SQLite/SQLiteTableJournalTests.cs
+++ b/src/DbUp.Tests/Support/SQLite/SQLiteTableJournalTests.cs
@@ -45,7 +45,7 @@ namespace DbUp.Tests.Support.SQLite
             var param2 = Substitute.For<IDbDataParameter>();
             dbConnection.CreateCommand().Returns(command);
             command.CreateParameter().Returns(param1, param2);
-            command.ExecuteScalar().Returns(x => 0L);
+            command.ExecuteScalar().Returns(x => { throw new SQLiteException("table not found"); });
             var consoleUpgradeLog = new ConsoleUpgradeLog();
             var journal = new SQLiteTableJournal(() => connectionManager, () => consoleUpgradeLog, "SchemaVersions");
 

--- a/src/DbUp.Tests/TestInfrastructure/RecordingDbCommand.cs
+++ b/src/DbUp.Tests/TestInfrastructure/RecordingDbCommand.cs
@@ -70,12 +70,8 @@ namespace DbUp.Tests.TestInfrastructure
         {
             add(DatabaseAction.ExecuteScalarCommand(CommandText));
 
-            if (CommandText == "error")
+            if (CommandText == "error" || (CommandText.ToLower().Contains("count") && CommandText.ToLower().Contains("schemaversion") && !schemaTableExists))
                 ThrowError();
-
-            if (CommandText.ToLower().Contains("count") && CommandText.ToLower().Contains("schemaversion") && !schemaTableExists)
-                return CommandText.Contains("sqlite") ? 0L : (object) null;
-
             return null;
         }
 

--- a/src/DbUp/Support/Firebird/FirebirdTableJournal.cs
+++ b/src/DbUp/Support/Firebird/FirebirdTableJournal.cs
@@ -161,9 +161,17 @@ namespace DbUp.Support.Firebird
         {
             return connectionManager().ExecuteCommandsWithManagedConnection(dbCommandFactory =>
             {
-                using (var command = dbCommandFactory())
+                try
                 {
-                    return VerifyTableExistsCommand(command);
+                    using (var command = dbCommandFactory())
+                    {
+                        return VerifyTableExistsCommand(command);
+                    }
+                }
+                // can't catch FbException here because this project does not depend upon Firebird
+                catch (DbException)
+                {
+                    return false;
                 }
             });
         }

--- a/src/DbUp/Support/MySql/MySqlITableJournal.cs
+++ b/src/DbUp/Support/MySql/MySqlITableJournal.cs
@@ -139,9 +139,16 @@ namespace DbUp.Support.MySql
         {
             return connectionManager().ExecuteCommandsWithManagedConnection(dbCommandFactory =>
             {
-                using (var command = dbCommandFactory())
+                try
                 {
-                    return VerifyTableExistsCommand(command, table, schema);
+                    using (var command = dbCommandFactory())
+                    {
+                        return VerifyTableExistsCommand(command, table, schema);
+                    }
+                }
+                catch (DbException)
+                {
+                    return false;
                 }
             });
         }

--- a/src/DbUp/Support/Postgresql/PostgresqlTableJournal.cs
+++ b/src/DbUp/Support/Postgresql/PostgresqlTableJournal.cs
@@ -151,9 +151,17 @@ namespace DbUp.Support.Postgresql
         {
             return connectionManager().ExecuteCommandsWithManagedConnection(dbCommandFactory =>
             {
-                using (var command = dbCommandFactory())
+                try
                 {
-                    return VerifyTableExistsCommand(command, table, schema);
+                    using (var command = dbCommandFactory())
+                    {
+                        return VerifyTableExistsCommand(command, table, schema);
+                    }
+                }
+                // can't catch NpgsqlException here because this project does not depend upon npgsql
+                catch (DbException)
+                {
+                    return false;
                 }
             });
         }

--- a/src/DbUp/Support/SqlServer/SqlTableJournal.cs
+++ b/src/DbUp/Support/SqlServer/SqlTableJournal.cs
@@ -167,9 +167,20 @@ namespace DbUp.Support.SqlServer
         {
             return connectionManager().ExecuteCommandsWithManagedConnection(dbCommandFactory =>
             {
-                using (var command = dbCommandFactory())
+                try
                 {
-                    return VerifyTableExistsCommand(command, table, schema);
+                    using (var command = dbCommandFactory())
+                    {
+                        return VerifyTableExistsCommand(command, table, schema);
+                    }
+                }
+                catch (SqlException)
+                {
+                    return false;
+                }
+                catch (DbException)
+                {
+                    return false;
                 }
             });
         }


### PR DESCRIPTION
Reverts DbUp/DbUp#276

I merged this, but then tried updating this for 4.0.0 and realised that this area of code has changed significantly and this fix is not needed. I'm not intending to create a new release for 3.x, so reverting this means the merge to 4.0 will be easier