### PR TITLE
add executionTimeout to DbUp.Console app so longer running scripts do…

### DIFF
--- a/src/DbUp.Console/Program.cs
+++ b/src/DbUp.Console/Program.cs
@@ -15,6 +15,7 @@ namespace DbUp.Console
             var username = "";
             var password = "";
             bool mark = false;
+            int executionTimeout = 30;
             var connectionString = "";
 
             bool show_help = false;
@@ -28,6 +29,7 @@ namespace DbUp.Console
                 { "cs|connectionString=", "Full connection string", cs => connectionString = cs},
                 { "h|help",  "show this message and exit", v => show_help = v != null },
                 {"mark", "Mark scripts as executed but take no action", m => mark = true},
+                {"et=|executionTimeout", "Execution Timeout (sec) | defaults to 30", et => executionTimeout = int.Parse(et)},
             };
 
             optionSet.Parse(args);
@@ -51,6 +53,7 @@ namespace DbUp.Console
             var dbup = DeployChanges.To
                 .SqlDatabase(connectionString)
                 .LogToConsole()
+                .WithExecutionTimeout(TimeSpan.FromSeconds(executionTimeout))
                 .WithScriptsFromFileSystem(directory)
                 .Build();
 


### PR DESCRIPTION
add executionTimeout to DbUp.Console app so longer running scripts do not timeout after the default of 30 seconds
