### PR TITLE
Order the scripts by name on "GetScripts"

### DIFF
--- a/src/DbUp/ScriptProviders/FileSystemScriptProvider.cs
+++ b/src/DbUp/ScriptProviders/FileSystemScriptProvider.cs
@@ -80,7 +80,9 @@ namespace DbUp.ScriptProviders
             {
                 files = files.Where(filter);
             }
-            return files.Select(x => SqlScript.FromFile(x, encoding)).ToList();
+            return files.Select(x => SqlScript.FromFile(x, encoding))
+                .OrderBy(x => x.Name)
+                .ToList();
         }
 
         private SearchOption ShouldSearchSubDirectories()


### PR DESCRIPTION
The scripts should be explicitly ordered by Name in the "GetScripts" method (Line 83/84), as in Linux (NET Core) environments the scripts are executing in random order.