### PR TITLE
GH-198 Add EnforceScriptOrder

### DIFF
--- a/src/dbup-core/Builder/StandardExtensions.cs
+++ b/src/dbup-core/Builder/StandardExtensions.cs
@@ -368,6 +368,17 @@ public static class StandardExtensions
     }
 
     /// <summary>
+    /// Sets a configuration flag which will cause the engine to throw an exception prior to execution if it detects scripts are to be run out of order
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    public static UpgradeEngineBuilder WithScriptOrderEnforced(this UpgradeEngineBuilder builder)
+    {
+        builder.Configure(c => c.EnforceScriptOrder = true);
+        return builder;
+    }
+
+    /// <summary>
     /// Allows you to set the execution timeout for scripts.
     /// </summary>
     /// <param name="builder">The builder.</param>

--- a/src/dbup-core/Builder/UpgradeConfiguration.cs
+++ b/src/dbup-core/Builder/UpgradeConfiguration.cs
@@ -68,6 +68,11 @@ namespace DbUp.Builder
         public bool VariablesEnabled { get; set; }
 
         /// <summary>
+        /// Ensures that scripts that appear earlier in the run order can not be run if a later script is found in the executed scripts
+        /// </summary>
+        public bool EnforceScriptOrder { get; set; }
+
+        /// <summary>
         /// Ensures all expectations have been met regarding this configuration.
         /// </summary>
         public void Validate()

--- a/src/dbup-core/Engine/ScriptsOutOfOrderException.cs
+++ b/src/dbup-core/Engine/ScriptsOutOfOrderException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace DbUp.Engine
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// ScriptsOutOfOrderException thrown when attempting to run scripts in an incorrect order if EnforceScriptOrder is specified
+    /// </summary>
+    public class ScriptsOutOfOrderException : Exception
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// ScriptsOutOfOrderException
+        /// </summary>
+        public ScriptsOutOfOrderException() : base("Scripts executed out of order") { }
+    }
+}

--- a/src/dbup-tests/ApprovalFiles/DbUp.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/DbUp.approved.cs
@@ -13,6 +13,7 @@ namespace DbUp.Builder
     {
         public UpgradeConfiguration() { }
         public DbUp.Engine.Transactions.IConnectionManager ConnectionManager { get; set; }
+        public bool EnforceScriptOrder { get; set; }
         public DbUp.Engine.IJournal Journal { get; set; }
         public DbUp.Engine.Output.IUpgradeLog Log { get; set; }
         public DbUp.Engine.IScriptExecutor ScriptExecutor { get; set; }
@@ -101,6 +102,10 @@ namespace DbUp.Engine
     {
         public LazySqlScript(string name, System.Func<string> contentProvider) { }
         public override string Contents { get; }
+    }
+    public class ScriptsOutOfOrderException : System.Exception
+    {
+        public ScriptsOutOfOrderException() { }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("{Name}")]
     public class SqlScript
@@ -423,6 +428,7 @@ public class static StandardExtensions
     public static DbUp.Builder.UpgradeEngineBuilder WithPreprocessor(this DbUp.Builder.UpgradeEngineBuilder builder, DbUp.Engine.IScriptPreprocessor preprocessor) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScript(this DbUp.Builder.UpgradeEngineBuilder builder, DbUp.Engine.SqlScript script) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScript(this DbUp.Builder.UpgradeEngineBuilder builder, string name, string contents) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptOrderEnforced(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScripts(this DbUp.Builder.UpgradeEngineBuilder builder, DbUp.Engine.IScriptProvider scriptProvider) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScripts(this DbUp.Builder.UpgradeEngineBuilder builder, System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> scripts) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScripts(this DbUp.Builder.UpgradeEngineBuilder builder, params DbUp.Engine.SqlScript[] scripts) { }


### PR DESCRIPTION
Ensures that scripts are executed in correct order.
If there are previously executed scripts, ensures that no other scripts are scheduled to run ahead of them, in the current order as provided by the script provider.
Saw on issue #198 that it was ok to pr into this branch a year and a half ago. Assuming that's still the case.