### PR TITLE
Ordered all scripts by name. Sped up the comparison of executed scripts.

### DIFF
--- a/src/dbup-core/Builder/StandardExtensions.cs
+++ b/src/dbup-core/Builder/StandardExtensions.cs
@@ -330,7 +330,21 @@ public static class StandardExtensions
     {
         return WithScripts(builder, new EmbeddedScriptAndCodeProvider(assembly, filter));
     }
-
+    
+    /// <summary>
+    /// Adds a sorter that sorts the scripts before filtering and execution
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="sorter">The sorter.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithSorter(this UpgradeEngineBuilder builder, IScriptSorter sorter)
+    {
+        builder.Configure(b => b.ScriptSorter = sorter);
+        return builder;
+    }
+    
     /// <summary>
     /// Adds a preprocessor that can replace portions of a script.
     /// </summary>

--- a/src/dbup-core/Builder/UpgradeConfiguration.cs
+++ b/src/dbup-core/Builder/UpgradeConfiguration.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using DbUp.Engine;
 using DbUp.Engine.Output;
+using DbUp.Engine.Sorters;
 using DbUp.Engine.Transactions;
 
 namespace DbUp.Builder
@@ -57,6 +58,11 @@ namespace DbUp.Builder
         /// Gets or sets the script executor, which runs scripts against the underlying database.
         /// </summary>
         public IScriptExecutor ScriptExecutor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the script sorter, which defines the order the scripts execute in
+        /// </summary>
+        public IScriptSorter ScriptSorter { get; set; } = new AlphabeticalScriptSorter();
 
         /// <summary>
         /// A collection of variables to be replaced in scripts before they are run

--- a/src/dbup-core/Engine/IScriptSorter.cs
+++ b/src/dbup-core/Engine/IScriptSorter.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace DbUp.Engine
+{
+    public interface IScriptSorter
+    {
+        IEnumerable<SqlScript> Sort(IEnumerable<SqlScript> filtered);
+    }
+}

--- a/src/dbup-core/Engine/Sorters/AlphabeticalScriptSorter.cs
+++ b/src/dbup-core/Engine/Sorters/AlphabeticalScriptSorter.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace DbUp.Engine.Sorters
+{
+    public class AlphabeticalScriptSorter : IScriptSorter
+    {
+        public IEnumerable<SqlScript> Sort(IEnumerable<SqlScript> filtered)
+            => filtered.OrderBy(s => s.Name);
+    }
+}

--- a/src/dbup-core/Engine/UpgradeEngine.cs
+++ b/src/dbup-core/Engine/UpgradeEngine.cs
@@ -100,9 +100,11 @@ namespace DbUp.Engine
         private List<SqlScript> GetScriptsToExecuteInsideOperation()
         {
             var allScripts = configuration.ScriptProviders.SelectMany(scriptProvider => scriptProvider.GetScripts(configuration.ConnectionManager));
-            var executedScripts = configuration.Journal.GetExecutedScripts();
+            var executedScriptNames = new HashSet<string>(configuration.Journal.GetExecutedScripts());
 
-            return allScripts.Where(s => !executedScripts.Any(y => y == s.Name)).ToList();
+            return allScripts.Where(s => !executedScriptNames.Contains(s.Name))
+                .OrderBy(s => s.Name)
+                .ToList();
         }
 
         public List<string> GetExecutedScripts()

--- a/src/dbup-core/Engine/UpgradeEngine.cs
+++ b/src/dbup-core/Engine/UpgradeEngine.cs
@@ -102,9 +102,9 @@ namespace DbUp.Engine
             var allScripts = configuration.ScriptProviders.SelectMany(scriptProvider => scriptProvider.GetScripts(configuration.ConnectionManager));
             var executedScriptNames = new HashSet<string>(configuration.Journal.GetExecutedScripts());
 
-            return allScripts.Where(s => !executedScriptNames.Contains(s.Name))
-                .OrderBy(s => s.Name)
-                .ToList();
+            var sorted = configuration.ScriptSorter.Sort(allScripts);
+            var filtered = sorted.Where(s => !executedScriptNames.Contains(s.Name));
+            return filtered.ToList();
         }
 
         public List<string> GetExecutedScripts()

--- a/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
@@ -34,6 +34,7 @@ public static class StandardExtensions
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Text.Encoding encoding) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Func<string, bool> filter, System.Text.Encoding encoding) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, DbUp.ScriptProviders.FileSystemScriptOptions options) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithSorter(this DbUp.Builder.UpgradeEngineBuilder builder, DbUp.Engine.IScriptSorter sorter) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithTransaction(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithTransactionPerScript(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithVariable(this DbUp.Builder.UpgradeEngineBuilder builder, string variableName, string value) { }
@@ -82,6 +83,7 @@ namespace DbUp.Builder
         public DbUp.Engine.IScriptExecutor ScriptExecutor { get; set; }
         public System.Collections.Generic.List<DbUp.Engine.IScriptPreprocessor> ScriptPreprocessors { get; }
         public System.Collections.Generic.List<DbUp.Engine.IScriptProvider> ScriptProviders { get; }
+        public DbUp.Engine.IScriptSorter ScriptSorter { get; set; }
         public System.Collections.Generic.Dictionary<string, string> Variables { get; }
         public bool VariablesEnabled { get; set; }
         public void AddVariables(System.Collections.Generic.IDictionary<string, string> newVariables) { }
@@ -126,6 +128,10 @@ namespace DbUp.Engine
     public interface IScriptProvider
     {
         System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> GetScripts(DbUp.Engine.Transactions.IConnectionManager connectionManager);
+    }
+    public interface IScriptSorter
+    {
+        System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> Sort(System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> filtered);
     }
     public interface ISqlObjectParser
     {
@@ -217,6 +223,14 @@ namespace DbUp.Engine.Preprocessors
         protected override void ReadCustomStatement() { }
         public string ReplaceVariables(System.Collections.Generic.IDictionary<string, string> variables) { }
         protected virtual bool ValidVariableNameCharacter(char c) { }
+    }
+}
+namespace DbUp.Engine.Sorters
+{
+    public class AlphabeticalScriptSorter : DbUp.Engine.IScriptSorter
+    {
+        public AlphabeticalScriptSorter() { }
+        public System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> Sort(System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> filtered) { }
     }
 }
 namespace DbUp.Engine.Transactions


### PR DESCRIPTION
Related to #298 
Resolves #180
I'm pretty sure the new default behaviour of running all scripts in order would be the expected behaviour instead of running each provider at a time.