### PR TITLE
Added Oracle (11g, 12c) support

### DIFF
--- a/src/DbUp.sln
+++ b/src/DbUp.sln
@@ -35,7 +35,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dbup-sqlite-mono", "dbup-sq
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{ACA9F575-BFC0-4FE1-BAB6-AE59FD8E5C26}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleApplication", "Samples\SampleApplication\SampleApplication.csproj", "{397F41BC-1076-4D1B-9620-C6051E8104F4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleApplication", "Samples\SampleApplication\SampleApplication.csproj", "{397F41BC-1076-4D1B-9620-C6051E8104F4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dbup-oracle", "dbup-oracle\dbup-oracle.csproj", "{8DAD25CC-ACF6-4A3A-A008-090C55E8FFA0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -83,17 +85,21 @@ Global
 		{397F41BC-1076-4D1B-9620-C6051E8104F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{397F41BC-1076-4D1B-9620-C6051E8104F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{397F41BC-1076-4D1B-9620-C6051E8104F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8DAD25CC-ACF6-4A3A-A008-090C55E8FFA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DAD25CC-ACF6-4A3A-A008-090C55E8FFA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DAD25CC-ACF6-4A3A-A008-090C55E8FFA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8DAD25CC-ACF6-4A3A-A008-090C55E8FFA0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{397F41BC-1076-4D1B-9620-C6051E8104F4} = {ACA9F575-BFC0-4FE1-BAB6-AE59FD8E5C26}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6807402B-EE7A-4324-A615-28F3499B1E9F}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = DbUp\DbUp.csproj
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{397F41BC-1076-4D1B-9620-C6051E8104F4} = {ACA9F575-BFC0-4FE1-BAB6-AE59FD8E5C26}
 	EndGlobalSection
 EndGlobal

--- a/src/dbup-core/Support/TableJournal.cs
+++ b/src/dbup-core/Support/TableJournal.cs
@@ -169,7 +169,7 @@ namespace DbUp.Support
             // TODO: Now we could run any migration scripts on it using some mechanism to make sure the table is ready for use.
         }
 
-        public void EnsureTableExistsAndIsLatestVersion(Func<IDbCommand> dbCommandFactory)
+        public virtual void EnsureTableExistsAndIsLatestVersion(Func<IDbCommand> dbCommandFactory)
         {
             if (!journalExists && !DoesTableExist(dbCommandFactory))
             {
@@ -200,6 +200,8 @@ namespace DbUp.Support
                     return false;
                 if (executeScalar is long)
                     return (long) executeScalar == 1;
+                if (executeScalar is decimal)
+                    return (decimal)executeScalar == 1;
                 return (int) executeScalar == 1;
             }
         }

--- a/src/dbup-oracle/OracleCommandReader.cs
+++ b/src/dbup-oracle/OracleCommandReader.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using DbUp.Support;
+
+namespace DbUp.Oracle
+{
+    public class OracleCommandReader : SqlCommandReader
+    {
+        private const string DelimiterKeyword = "DELIMITER";
+
+        /// <summary>
+        /// Creates an instance of MySqlCommandReader
+        /// </summary>
+        public OracleCommandReader(string sqlText) : base(sqlText, ";", delimiterRequiresWhitespace: false)
+        {
+        }
+
+        /// <summary>
+        /// Hook to support custom statements
+        /// </summary>
+        protected override bool IsCustomStatement
+        {
+            get
+            {
+                string statement;
+                return TryPeek(DelimiterKeyword.Length, out statement) &&
+                       string.Equals(DelimiterKeyword, statement, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        /// <summary>
+        /// Read a custom statement
+        /// </summary>
+        protected override void ReadCustomStatement()
+        {
+            // Move past Delimiter keyword
+            var count = DelimiterKeyword.Length + 1;
+            Read(new char[count], 0, count);
+
+            SkipWhitespace();
+            // Read until we hit the end of line.
+            var delimiter = new StringBuilder();
+            do
+            {
+                delimiter.Append(CurrentChar);
+                if (Read() == FailedRead)
+                {
+                    break;
+                }
+            }
+            while (!IsEndOfLine && !IsWhiteSpace);
+
+            Delimiter = delimiter.ToString();
+        }
+
+        private void SkipWhitespace()
+        {
+            while (char.IsWhiteSpace(CurrentChar))
+            {
+                Read();
+            }
+        }
+    }
+}

--- a/src/dbup-oracle/OracleCommandSplitter.cs
+++ b/src/dbup-oracle/OracleCommandSplitter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DbUp.Oracle
+{
+    public class OracleCommandSplitter
+    {
+        /// <summary>
+        /// Splits a script with multiple delimited commands into commands
+        /// </summary>
+        /// <param name="scriptContents"></param>
+        /// <returns></returns>
+        public IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
+        {
+            using (var reader = new OracleCommandReader(scriptContents))
+            {
+                var commands = new List<string>();
+                reader.ReadAllCommands(c => commands.Add(c));
+                return commands;
+            }
+        }
+    }
+}

--- a/src/dbup-oracle/OracleConnectionManager.cs
+++ b/src/dbup-oracle/OracleConnectionManager.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DbUp.Engine.Transactions;
+using Oracle.ManagedDataAccess.Client;
+
+namespace DbUp.Oracle
+{
+    public class OracleConnectionManager : DatabaseConnectionManager
+    {
+        /// <summary>
+        /// Creates a new MySql database connection.
+        /// </summary>
+        /// <param name="connectionString">The MySql connection string.</param>
+        public OracleConnectionManager(string connectionString) : base(new DelegateConnectionFactory(l => new OracleConnection(connectionString)))
+        {
+        }
+
+        public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
+        {
+            var commandSplitter = new OracleCommandSplitter();
+            var scriptStatements = commandSplitter.SplitScriptIntoCommands(scriptContents);
+            return scriptStatements;
+        }
+    }
+}

--- a/src/dbup-oracle/OracleExtensions.cs
+++ b/src/dbup-oracle/OracleExtensions.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DbUp.Builder;
+using DbUp.Engine.Output;
+using DbUp.Engine.Transactions;
+
+namespace DbUp.Oracle
+{
+    public static class OracleExtensions
+    {
+        public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, string connectionString)
+        {
+            foreach (var pair in connectionString.Split(';').Select(s => s.Split('=')).Where(pair => pair.Length == 2).Where(pair => pair[0].ToLower() == "database"))
+            {
+                return OracleDatabase(new OracleConnectionManager(connectionString), pair[1]);
+            }
+
+            return OracleDatabase(new OracleConnectionManager(connectionString));
+        }
+
+        /// <summary>
+        /// Creates an upgrader for MySql databases.
+        /// </summary>
+        /// <param name="supported">Fluent helper type.</param>
+        /// <param name="connectionString">MySql database connection string.</param>
+        /// <param name="schema">Which MySql schema to check for changes</param>
+        /// <returns>
+        /// A builder for a database upgrader designed for MySql databases.
+        /// </returns>
+        public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, string connectionString, string schema)
+        {
+            return OracleDatabase(new OracleConnectionManager(connectionString), schema);
+        }
+
+        /// <summary>
+        /// Creates an upgrader for MySql databases.
+        /// </summary>
+        /// <param name="supported">Fluent helper type.</param>
+        /// <param name="connectionManager">The <see cref="MySqlConnectionManager"/> to be used during a database upgrade.</param>
+        /// <returns>
+        /// A builder for a database upgrader designed for MySql databases.
+        /// </returns>
+        public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, IConnectionManager connectionManager)
+            => OracleDatabase(connectionManager);
+
+        /// <summary>
+        /// Creates an upgrader for MySql databases.
+        /// </summary>
+        /// <param name="connectionManager">The <see cref="MySqlConnectionManager"/> to be used during a database upgrade.</param>
+        /// <returns>
+        /// A builder for a database upgrader designed for MySql databases.
+        /// </returns>
+        public static UpgradeEngineBuilder OracleDatabase(IConnectionManager connectionManager)
+        {
+            return OracleDatabase(connectionManager, null);
+        }
+
+        /// <summary>
+        /// Creates an upgrader for MySql databases.
+        /// </summary>
+        /// <param name="connectionManager">The <see cref="MySqlConnectionManager"/> to be used during a database upgrade.</param>
+        /// /// <param name="schema">Which MySQL schema to check for changes</param>
+        /// <returns>
+        /// A builder for a database upgrader designed for MySql databases.
+        /// </returns>
+        public static UpgradeEngineBuilder OracleDatabase(IConnectionManager connectionManager, string schema)
+        {
+            var builder = new UpgradeEngineBuilder();
+            builder.Configure(c => c.ConnectionManager = connectionManager);
+            builder.Configure(c => c.ScriptExecutor = new OracleScriptExecutor(() => c.ConnectionManager, () => c.Log, null, () => c.VariablesEnabled, c.ScriptPreprocessors, () => c.Journal));
+            builder.Configure(c => c.Journal = new OracleTableJournal(() => c.ConnectionManager, () => c.Log, schema, "schemaversions"));
+            builder.WithPreprocessor(new OraclePreprocessor());
+            return builder;
+        }
+    }
+}

--- a/src/dbup-oracle/OracleObjectParser.cs
+++ b/src/dbup-oracle/OracleObjectParser.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DbUp.Support;
+
+namespace DbUp.Oracle
+{
+    public class OracleObjectParser : SqlObjectParser
+    {
+        public OracleObjectParser() : base("\"", "\"")
+        {
+        }
+    }
+}

--- a/src/dbup-oracle/OraclePreprocessor.cs
+++ b/src/dbup-oracle/OraclePreprocessor.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DbUp.Engine;
+
+namespace DbUp.Oracle
+{
+    public class OraclePreprocessor : IScriptPreprocessor
+    {
+        public string Process(string contents)
+        {
+            return contents;
+        }
+    }
+}

--- a/src/dbup-oracle/OracleScriptExecutor.cs
+++ b/src/dbup-oracle/OracleScriptExecutor.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DbUp.Engine;
+using DbUp.Engine.Output;
+using DbUp.Engine.Transactions;
+using DbUp.Support;
+using Oracle.ManagedDataAccess.Client;
+
+namespace DbUp.Oracle
+{
+    public class OracleScriptExecutor : ScriptExecutor
+    {
+        /// <summary>
+        /// Initializes an instance of the <see cref="OracleScriptExecutor"/> class.
+        /// </summary>
+        /// <param name="connectionManagerFactory"></param>
+        /// <param name="log">The logging mechanism.</param>
+        /// <param name="schema">The schema that contains the table.</param>
+        /// <param name="variablesEnabled">Function that returns <c>true</c> if variables should be replaced, <c>false</c> otherwise.</param>
+        /// <param name="scriptPreprocessors">Script Preprocessors in addition to variable substitution</param>
+        /// <param name="journalFactory">Database journal</param>
+        public OracleScriptExecutor(Func<IConnectionManager> connectionManagerFactory, Func<IUpgradeLog> log, string schema, Func<bool> variablesEnabled,
+            IEnumerable<IScriptPreprocessor> scriptPreprocessors, Func<IJournal> journalFactory)
+            : base(connectionManagerFactory, new OracleObjectParser(), log, schema, variablesEnabled, scriptPreprocessors, journalFactory)
+        {
+
+        }
+
+        protected override string GetVerifySchemaSql(string schema)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Executes the specified script against a database at a given connection string.
+        /// </summary>
+        /// <param name="script">The script.</param>
+        public override void Execute(SqlScript script)
+        {
+            Execute(script, null);
+        }
+
+        protected override void ExecuteCommandsWithinExceptionHandler(int index, SqlScript script, Action excuteCommand)
+        {
+            try
+            {
+                excuteCommand();
+            }
+            catch (OracleException exception)
+            {
+#if MY_SQL_DATA_6_9_5
+                var code = exception.ErrorCode;
+#else
+                var code = exception.ErrorCode;
+#endif
+                Log().WriteInformation("Oracle exception has occured in script: '{0}'", script.Name);
+                Log().WriteError("Oracle error code: {0}; Number {1}; Message: {2}", index, code, exception.Number, exception.Message);
+                Log().WriteError(exception.ToString());
+                throw;
+            }
+        }
+    }
+}

--- a/src/dbup-oracle/OracleTableJournal.cs
+++ b/src/dbup-oracle/OracleTableJournal.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.Text;
+using DbUp.Engine.Output;
+using DbUp.Engine.Transactions;
+using DbUp.Support;
+
+namespace DbUp.Oracle
+{
+    public class OracleTableJournal : TableJournal
+    {
+        bool journalExists;
+        /// <summary>
+        /// Creates a new MySql table journal.
+        /// </summary>
+        /// <param name="connectionManager">The MySql connection manager.</param>
+        /// <param name="logger">The upgrade logger.</param>
+        /// <param name="schema">The name of the schema the journal is stored in.</param>
+        /// <param name="table">The name of the journal table.</param>
+        public OracleTableJournal(Func<IConnectionManager> connectionManager, Func<IUpgradeLog> logger, string schema, string table)
+            : base(connectionManager, logger, new OracleObjectParser(), schema, table)
+        {
+        }
+
+        public static CultureInfo English = new CultureInfo("en-US", false);
+
+        protected override string CreateSchemaTableSql(string quotedPrimaryKeyName)
+        {
+            var fqSchemaTableName = this.UnquotedSchemaTableName;
+            return
+                $@" CREATE TABLE {fqSchemaTableName} 
+                (
+                    schemaversionid NUMBER(10),
+                    scriptname VARCHAR2(255) NOT NULL,
+                    applied TIMESTAMP NOT NULL,
+                    CONSTRAINT PK_{ fqSchemaTableName } PRIMARY KEY (schemaversionid) 
+                )";
+        }
+
+        protected string CreateSchemaTableSequenceSql()
+        {
+            var fqSchemaTableName = this.UnquotedSchemaTableName;
+            return $@" CREATE SEQUENCE {fqSchemaTableName}_sequence";
+        }
+
+        protected string CreateSchemaTableTriggerSql()
+        {
+            var fqSchemaTableName = this.UnquotedSchemaTableName;
+            return $@" CREATE OR REPLACE TRIGGER {fqSchemaTableName}_on_insert
+                    BEFORE INSERT ON {fqSchemaTableName}
+                    FOR EACH ROW
+                    BEGIN
+                        SELECT {fqSchemaTableName}_sequence.nextval
+                        INTO :new.schemaversionid
+                        FROM dual;
+                    END;
+                ";
+        }
+
+        protected override string GetInsertJournalEntrySql(string scriptName, string applied)
+        {
+            var unquotedSchemaTableName = UnquotedSchemaTableName.ToUpper(English);
+            return $"insert into {unquotedSchemaTableName} (ScriptName, Applied) values (:" + scriptName.Replace("@","") + ",:" + applied.Replace("@","") + ")";
+        }
+
+        protected override string GetJournalEntriesSql()
+        {
+            var unquotedSchemaTableName = UnquotedSchemaTableName.ToUpper(English);
+            return $"select scriptname from {unquotedSchemaTableName} order by scriptname";
+        }
+
+        protected override string DoesTableExistSql()
+        {
+            var unquotedSchemaTableName = UnquotedSchemaTableName.ToUpper(English);
+            return $"select 1 from user_tables where table_name = '{unquotedSchemaTableName}'";
+        }
+
+        protected IDbCommand GetCreateTableSequence(Func<IDbCommand> dbCommandFactory)
+        {
+            var command = dbCommandFactory();
+            command.CommandText = CreateSchemaTableSequenceSql();
+            command.CommandType = CommandType.Text;
+            return command;
+        }
+
+        protected IDbCommand GetCreateTableTrigger(Func<IDbCommand> dbCommandFactory)
+        {
+            var command = dbCommandFactory();
+            command.CommandText = CreateSchemaTableTriggerSql();
+            command.CommandType = CommandType.Text;
+            return command;
+        }
+
+        public override void EnsureTableExistsAndIsLatestVersion(Func<IDbCommand> dbCommandFactory)
+        {
+            if (!journalExists && !DoesTableExist(dbCommandFactory))
+            {
+                Log().WriteInformation(string.Format("Creating the {0} table", FqSchemaTableName));
+
+                // We will never change the schema of the initial table create.
+                using (var command = GetCreateTableSequence(dbCommandFactory))
+                {
+                    command.ExecuteNonQuery();
+                }
+
+                // We will never change the schema of the initial table create.
+                using (var command = GetCreateTableCommand(dbCommandFactory))
+                {
+                    command.ExecuteNonQuery();
+                }
+
+                // We will never change the schema of the initial table create.
+                using (var command = GetCreateTableTrigger(dbCommandFactory))
+                {
+                    command.ExecuteNonQuery();
+                }
+
+                Log().WriteInformation(string.Format("The {0} table has been created", FqSchemaTableName));
+
+                OnTableCreated(dbCommandFactory);
+            }
+
+            journalExists = true;
+        }
+
+        protected new bool DoesTableExist(Func<IDbCommand> dbCommandFactory)
+        {
+            Log().WriteInformation("Checking whether journal table exists..");
+            using (var command = dbCommandFactory())
+            {
+                command.CommandText = DoesTableExistSql();
+                command.CommandType = CommandType.Text;
+                var executeScalar = command.ExecuteScalar();
+                if (executeScalar == null)
+                    return false;
+                if (executeScalar is long)
+                    return (long)executeScalar == 1;
+                return (decimal)executeScalar == 1;
+            }
+        }
+    }
+}

--- a/src/dbup-oracle/OracleTableJournal.cs
+++ b/src/dbup-oracle/OracleTableJournal.cs
@@ -124,21 +124,5 @@ namespace DbUp.Oracle
 
             journalExists = true;
         }
-
-        protected new bool DoesTableExist(Func<IDbCommand> dbCommandFactory)
-        {
-            Log().WriteInformation("Checking whether journal table exists..");
-            using (var command = dbCommandFactory())
-            {
-                command.CommandText = DoesTableExistSql();
-                command.CommandType = CommandType.Text;
-                var executeScalar = command.ExecuteScalar();
-                if (executeScalar == null)
-                    return false;
-                if (executeScalar is long)
-                    return (long)executeScalar == 1;
-                return (decimal)executeScalar == 1;
-            }
-        }
     }
 }

--- a/src/dbup-oracle/dbup-oracle.csproj
+++ b/src/dbup-oracle/dbup-oracle.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Oracle.ManagedDataAccess.Core">
+      <Version>2.12.0-beta2</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="Oracle.ManagedDataAccess">
+      <Version>12.2.1100</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/dbup-tests/ApiTests.cs
+++ b/src/dbup-tests/ApiTests.cs
@@ -13,6 +13,7 @@ using Assent.Namers;
 using Castle.Core.Internal;
 using DbUp.Builder;
 using DbUp.Engine;
+using DbUp.Oracle;
 using NSubstitute.Core;
 using Shouldly;
 using Xunit;
@@ -25,6 +26,7 @@ namespace DbUp.Tests
         [InlineData(typeof(UpgradeEngine))]
         [InlineData(typeof(SQLiteExtensions))]
         [InlineData(typeof(MySqlExtensions))]
+        [InlineData(typeof(OracleExtensions))]
         [InlineData(typeof(PostgresqlExtensions))]
 #if !NETCORE
         [InlineData(typeof(FirebirdExtensions))]

--- a/src/dbup-tests/ApprovalFiles/DatabaseSupportTests.VerifyBasicSupport.Oracle.approved.txt
+++ b/src/dbup-tests/ApprovalFiles/DatabaseSupportTests.VerifyBasicSupport.Oracle.approved.txt
@@ -1,0 +1,42 @@
+DB Operation: Open connection
+Info:         Beginning database upgrade
+Info:         Checking whether journal table exists..
+DB Operation: Execute scalar command: select 1 from user_tables where table_name = 'SCHEMAVERSIONS'
+DB Operation: Dispose command
+Info:         Journal table does not exist
+Info:         Executing Database Server script 'Script0001.sql'
+Info:         Checking whether journal table exists..
+DB Operation: Execute scalar command: select 1 from user_tables where table_name = 'SCHEMAVERSIONS'
+DB Operation: Dispose command
+Info:         Creating the "schemaversions" table
+DB Operation: Execute non query command:  CREATE SEQUENCE schemaversions_sequence
+DB Operation: Dispose command
+DB Operation: Execute non query command:  CREATE TABLE schemaversions 
+                (
+                    schemaversionid NUMBER(10),
+                    scriptname VARCHAR2(255) NOT NULL,
+                    applied TIMESTAMP NOT NULL,
+                    CONSTRAINT PK_schemaversions PRIMARY KEY (schemaversionid) 
+                )
+DB Operation: Dispose command
+DB Operation: Execute non query command:  CREATE OR REPLACE TRIGGER schemaversions_on_insert
+                    BEFORE INSERT ON schemaversions
+                    FOR EACH ROW
+                    BEGIN
+                        SELECT schemaversions_sequence.nextval
+                        INTO :new.schemaversionid
+                        FROM dual;
+                    END;
+                
+DB Operation: Dispose command
+Info:         The "schemaversions" table has been created
+DB Operation: Execute non query command: script1contents
+DB Operation: Dispose command
+DB Operation: Create parameter
+Info:         DB Operation: Add parameter to command: scriptName=Script0001.sql
+DB Operation: Create parameter
+Info:         DB Operation: Add parameter to command: applied=<date>
+DB Operation: Execute non query command: insert into SCHEMAVERSIONS (ScriptName, Applied) values (:scriptName,:applied)
+DB Operation: Dispose command
+Info:         Upgrade successful
+DB Operation: Dispose connection

--- a/src/dbup-tests/ApprovalFiles/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.Oracle.approved.txt
+++ b/src/dbup-tests/ApprovalFiles/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.Oracle.approved.txt
@@ -1,0 +1,42 @@
+DB Operation: Open connection
+Info:         Beginning database upgrade
+Info:         Checking whether journal table exists..
+DB Operation: Execute scalar command: select 1 from user_tables where table_name = 'TESTSCHEMAVERSIONS'
+DB Operation: Dispose command
+Info:         Journal table does not exist
+Info:         Executing Database Server script 'Script0001.sql'
+Info:         Checking whether journal table exists..
+DB Operation: Execute scalar command: select 1 from user_tables where table_name = 'TESTSCHEMAVERSIONS'
+DB Operation: Dispose command
+Info:         Creating the "test"."TestSchemaVersions" table
+DB Operation: Execute non query command:  CREATE SEQUENCE TestSchemaVersions_sequence
+DB Operation: Dispose command
+DB Operation: Execute non query command:  CREATE TABLE TestSchemaVersions 
+                (
+                    schemaversionid NUMBER(10),
+                    scriptname VARCHAR2(255) NOT NULL,
+                    applied TIMESTAMP NOT NULL,
+                    CONSTRAINT PK_TestSchemaVersions PRIMARY KEY (schemaversionid) 
+                )
+DB Operation: Dispose command
+DB Operation: Execute non query command:  CREATE OR REPLACE TRIGGER TestSchemaVersions_on_insert
+                    BEFORE INSERT ON TestSchemaVersions
+                    FOR EACH ROW
+                    BEGIN
+                        SELECT TestSchemaVersions_sequence.nextval
+                        INTO :new.schemaversionid
+                        FROM dual;
+                    END;
+                
+DB Operation: Dispose command
+Info:         The "test"."TestSchemaVersions" table has been created
+DB Operation: Execute non query command: script1contents
+DB Operation: Dispose command
+DB Operation: Create parameter
+Info:         DB Operation: Add parameter to command: scriptName=Script0001.sql
+DB Operation: Create parameter
+Info:         DB Operation: Add parameter to command: applied=<date>
+DB Operation: Execute non query command: insert into TESTSCHEMAVERSIONS (ScriptName, Applied) values (:scriptName,:applied)
+DB Operation: Dispose command
+Info:         Upgrade successful
+DB Operation: Dispose connection

--- a/src/dbup-tests/ApprovalFiles/DatabaseSupportTests.VerifyVariableSubstitutions.Oracle.approved.txt
+++ b/src/dbup-tests/ApprovalFiles/DatabaseSupportTests.VerifyVariableSubstitutions.Oracle.approved.txt
@@ -1,0 +1,42 @@
+DB Operation: Open connection
+Info:         Beginning database upgrade
+Info:         Checking whether journal table exists..
+DB Operation: Execute scalar command: select 1 from user_tables where table_name = 'SCHEMAVERSIONS'
+DB Operation: Dispose command
+Info:         Journal table does not exist
+Info:         Executing Database Server script 'Script0001.sql'
+Info:         Checking whether journal table exists..
+DB Operation: Execute scalar command: select 1 from user_tables where table_name = 'SCHEMAVERSIONS'
+DB Operation: Dispose command
+Info:         Creating the "schemaversions" table
+DB Operation: Execute non query command:  CREATE SEQUENCE schemaversions_sequence
+DB Operation: Dispose command
+DB Operation: Execute non query command:  CREATE TABLE schemaversions 
+                (
+                    schemaversionid NUMBER(10),
+                    scriptname VARCHAR2(255) NOT NULL,
+                    applied TIMESTAMP NOT NULL,
+                    CONSTRAINT PK_schemaversions PRIMARY KEY (schemaversionid) 
+                )
+DB Operation: Dispose command
+DB Operation: Execute non query command:  CREATE OR REPLACE TRIGGER schemaversions_on_insert
+                    BEFORE INSERT ON schemaversions
+                    FOR EACH ROW
+                    BEGIN
+                        SELECT schemaversions_sequence.nextval
+                        INTO :new.schemaversionid
+                        FROM dual;
+                    END;
+                
+DB Operation: Dispose command
+Info:         The "schemaversions" table has been created
+DB Operation: Execute non query command: print SubstitutedValue
+DB Operation: Dispose command
+DB Operation: Create parameter
+Info:         DB Operation: Add parameter to command: scriptName=Script0001.sql
+DB Operation: Create parameter
+Info:         DB Operation: Add parameter to command: applied=<date>
+DB Operation: Execute non query command: insert into SCHEMAVERSIONS (ScriptName, Applied) values (:scriptName,:applied)
+DB Operation: Dispose command
+Info:         Upgrade successful
+DB Operation: Dispose connection

--- a/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
@@ -465,7 +465,7 @@ namespace DbUp.Support
         protected abstract string CreateSchemaTableSql(string quotedPrimaryKeyName);
         protected bool DoesTableExist(System.Func<System.Data.IDbCommand> dbCommandFactory) { }
         protected virtual string DoesTableExistSql() { }
-        public void EnsureTableExistsAndIsLatestVersion(System.Func<System.Data.IDbCommand> dbCommandFactory) { }
+        public virtual void EnsureTableExistsAndIsLatestVersion(System.Func<System.Data.IDbCommand> dbCommandFactory) { }
         protected System.Data.IDbCommand GetCreateTableCommand(System.Func<System.Data.IDbCommand> dbCommandFactory) { }
         public string[] GetExecutedScripts() { }
         protected abstract string GetInsertJournalEntrySql(string scriptName, string applied);

--- a/src/dbup-tests/ApprovalFiles/dbup-oracle.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-oracle.approved.cs
@@ -1,0 +1,58 @@
+
+namespace DbUp.Oracle
+{
+    public class OracleCommandReader : DbUp.Support.SqlCommandReader, System.IDisposable
+    {
+        public OracleCommandReader(string sqlText) { }
+        protected override bool IsCustomStatement { get; }
+        protected override void ReadCustomStatement() { }
+    }
+    public class OracleCommandSplitter
+    {
+        public OracleCommandSplitter() { }
+        public System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
+    }
+    public class OracleConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
+    {
+        public OracleConnectionManager(string connectionString) { }
+        public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
+    }
+    public static class OracleExtensions
+    {
+        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
+        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
+        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
+        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
+        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema) { }
+    }
+    public class OracleObjectParser : DbUp.Support.SqlObjectParser, DbUp.Engine.ISqlObjectParser
+    {
+        public OracleObjectParser() { }
+    }
+    public class OraclePreprocessor : DbUp.Engine.IScriptPreprocessor
+    {
+        public OraclePreprocessor() { }
+        public string Process(string contents) { }
+    }
+    public class OracleScriptExecutor : DbUp.Support.ScriptExecutor, DbUp.Engine.IScriptExecutor
+    {
+        public OracleScriptExecutor(System.Func<DbUp.Engine.Transactions.IConnectionManager> connectionManagerFactory, System.Func<DbUp.Engine.Output.IUpgradeLog> log, string schema, System.Func<bool> variablesEnabled, System.Collections.Generic.IEnumerable<DbUp.Engine.IScriptPreprocessor> scriptPreprocessors, System.Func<DbUp.Engine.IJournal> journalFactory) { }
+        public override void Execute(DbUp.Engine.SqlScript script) { }
+        protected override void ExecuteCommandsWithinExceptionHandler(int index, DbUp.Engine.SqlScript script, System.Action excuteCommand) { }
+        protected override string GetVerifySchemaSql(string schema) { }
+    }
+    public class OracleTableJournal : DbUp.Support.TableJournal, DbUp.Engine.IJournal
+    {
+        public static System.Globalization.CultureInfo English;
+        public OracleTableJournal(System.Func<DbUp.Engine.Transactions.IConnectionManager> connectionManager, System.Func<DbUp.Engine.Output.IUpgradeLog> logger, string schema, string table) { }
+        protected string CreateSchemaTableSequenceSql() { }
+        protected override string CreateSchemaTableSql(string quotedPrimaryKeyName) { }
+        protected string CreateSchemaTableTriggerSql() { }
+        protected override string DoesTableExistSql() { }
+        public override void EnsureTableExistsAndIsLatestVersion(System.Func<System.Data.IDbCommand> dbCommandFactory) { }
+        protected System.Data.IDbCommand GetCreateTableSequence(System.Func<System.Data.IDbCommand> dbCommandFactory) { }
+        protected System.Data.IDbCommand GetCreateTableTrigger(System.Func<System.Data.IDbCommand> dbCommandFactory) { }
+        protected override string GetInsertJournalEntrySql(string scriptName, string applied) { }
+        protected override string GetJournalEntriesSql() { }
+    }
+}

--- a/src/dbup-tests/DatabaseSupportTests.cs
+++ b/src/dbup-tests/DatabaseSupportTests.cs
@@ -13,6 +13,7 @@ using DbUp.Tests.TestInfrastructure;
 using Shouldly;
 using TestStack.BDDfy;
 using Xunit;
+using DbUp.Oracle;
 
 #if !NETCORE
 using DbUp.Firebird;
@@ -95,11 +96,13 @@ namespace DbUp.Tests
                         builder.Configure(c => c.Journal = new SQLiteTableJournal(() => c.ConnectionManager, () => c.Log, tableName));
                         return builder;
                     })),
+                    new ExampleAction("Oracle", Deploy(to => to.OracleDatabase(string.Empty), (builder, schema, tableName) => { builder.Configure(c => c.Journal = new OracleTableJournal(()=>c.ConnectionManager, ()=>c.Log, schema, tableName)); return builder; })),
+
 #if !NETCORE
                     new ExampleAction("Firebird", Deploy(to => to.FirebirdDatabase(string.Empty), (builder, schema, tableName) => { builder.Configure(c => c.Journal = new FirebirdTableJournal(()=>c.ConnectionManager, ()=>c.Log, tableName)); return builder; })),
                     new ExampleAction("PostgreSQL", Deploy(to => to.PostgresqlDatabase(string.Empty), (builder, schema, tableName) => { builder.Configure(c => c.Journal = new PostgresqlTableJournal(()=>c.ConnectionManager, ()=>c.Log, schema, tableName)); return builder; })),
                     new ExampleAction("SqlCe", Deploy(to => to.SqlCeDatabase(string.Empty), (builder, schema, tableName) => { builder.Configure(c => c.Journal = new SqlTableJournal(()=>c.ConnectionManager, ()=>c.Log, schema, tableName)); return builder; })),
-                    new ExampleAction("MySql", Deploy(to => to.MySqlDatabase(string.Empty), (builder, schema, tableName) => { builder.Configure(c => c.Journal = new MySqlTableJournal(()=>c.ConnectionManager, ()=>c.Log, schema, tableName)); return builder; }))
+                    new ExampleAction("MySql", Deploy(to => to.MySqlDatabase(string.Empty), (builder, schema, tableName) => { builder.Configure(c => c.Journal = new MySqlTableJournal(()=>c.ConnectionManager, ()=>c.Log, schema, tableName)); return builder; }))                    
 #endif
                 };
             }

--- a/src/dbup-tests/Support/Oracle/OracleConnectionManagerTests.cs
+++ b/src/dbup-tests/Support/Oracle/OracleConnectionManagerTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DbUp.Oracle;
+using Shouldly;
+using Xunit;
+
+namespace DbUp.Tests.Support.Oracle
+{
+    public class OracleConnectionManagerTests
+    {
+        [Fact]
+        public void CanParseSingleLineScript()
+        {
+            const string singleCommand = "create table FOO (myid INT NOT NULL);";
+
+            var connectionManager = new OracleConnectionManager("connectionstring");
+            var result = connectionManager.SplitScriptIntoCommands(singleCommand);
+
+            result.Count().ShouldBe(1);
+        }
+
+        [Fact]
+        public void CanParseMultilineScript()
+        {
+            var multiCommand = "create table FOO (myid INT NOT NULL);";
+            multiCommand += Environment.NewLine;
+            multiCommand += "create table BAR (myid INT NOT NULL);";
+
+            var connectionManager = new OracleConnectionManager("connectionstring");
+            var result = connectionManager.SplitScriptIntoCommands(multiCommand);
+
+            result.Count().ShouldBe(2);
+        }
+    }
+}

--- a/src/dbup-tests/dbup-tests.csproj
+++ b/src/dbup-tests/dbup-tests.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
+    <ProjectReference Include="..\dbup-oracle\dbup-oracle.csproj" />
     <ProjectReference Include="..\dbup-sqlserver\dbup-sqlserver.csproj" />
     <ProjectReference Include="..\dbup-sqlite\dbup-sqlite.csproj" />
     <ProjectReference Include="..\dbup-mysql\dbup-mysql.csproj" />


### PR DESCRIPTION
I have forked the master branch and added Oracle support (11g, 12c). 
**db-oracle** project works on .netstandart2.0 and net45. look forward to hearing any feedback. 

Simple Changes in **TableJournal** class:

- make **EnsureTableExistsAndIsLatestVersion** method virtual, so I can override it in **OracleTableJournal**: Oracle 11 g does not support auto increment id, so I have created a sequence and insert trigger beside schemaversions table.
- **DoesTableExist** method body: Oracle returns scalar as a decimal value.