### PR TITLE
Change delimiter from semicolon to slash to support package, trigger, procedure creation

### DIFF
--- a/src/dbup-oracle/OracleCommandReader.cs
+++ b/src/dbup-oracle/OracleCommandReader.cs
@@ -13,7 +13,7 @@ namespace DbUp.Oracle
         /// <summary>
         /// Creates an instance of MySqlCommandReader
         /// </summary>
-        public OracleCommandReader(string sqlText) : base(sqlText, ";", delimiterRequiresWhitespace: false)
+        public OracleCommandReader(string sqlText) : base(sqlText, "/", delimiterRequiresWhitespace: false)
         {
         }
 
@@ -25,8 +25,8 @@ namespace DbUp.Oracle
             get
             {
                 string statement;
-                return TryPeek(DelimiterKeyword.Length, out statement) &&
-                       string.Equals(DelimiterKeyword, statement, StringComparison.OrdinalIgnoreCase);
+                return TryPeek(DelimiterKeyword.Length - 1, out statement) &&
+                       string.Equals(DelimiterKeyword, CurrentChar + statement, StringComparison.OrdinalIgnoreCase);
             }
         }
 

--- a/src/dbup-tests/Support/Oracle/OracleConnectionManagerTests.cs
+++ b/src/dbup-tests/Support/Oracle/OracleConnectionManagerTests.cs
@@ -25,9 +25,9 @@ namespace DbUp.Tests.Support.Oracle
         [Fact]
         public void CanParseMultilineScript()
         {
-            var multiCommand = "create table FOO (myid INT NOT NULL);";
+            var multiCommand = "create table FOO (myid INT NOT NULL)/";
             multiCommand += Environment.NewLine;
-            multiCommand += "create table BAR (myid INT NOT NULL);";
+            multiCommand += "create table BAR (myid INT NOT NULL)/";
 
             var connectionManager = new OracleConnectionManager("connectionstring");
             var result = connectionManager.SplitScriptIntoCommands(multiCommand);


### PR DESCRIPTION
Related with #334 and #224, I will change delimiter character from semicolon (;) to slash (/). Slash character is more appropriate, because of pl/sql block statements.

Semicolon works for sample sql statements like insert, update, delete, create etc. 

But for creating trigger, procedure, package etc. we have to use multiple statements with semicolon delimiter, and slash for the last statement.
Slash tells where the entire procedure ends and execute it as a unit rather than executing the individual statements inside.

Example script (script001.sql):

```
CREATE TABLE products 
(
  product_id number(10) NOT NULL,
  product_name varchar2(50) NOT NULL,
  product_category varchar2(1) NOT NULL,
  product_date DATE,
  CONSTRAINT products_pk PRIMARY KEY (product_id)
)
/
create sequence product_seq
/
insert into PRODUCTS (PRODUCT_ID, PRODUCT_NAME, PRODUCT_CATEGORY, PRODUCT_DATE) values (PRODUCT_SEQ.nextval, 'test', 'T', Current_date)
/
insert into PRODUCTS (PRODUCT_ID, PRODUCT_NAME, PRODUCT_CATEGORY, PRODUCT_DATE) values (PRODUCT_SEQ.nextval, 'test', 'Z', Current_date)
/

CREATE OR REPLACE TRIGGER orders_before_insert
BEFORE INSERT
   ON orders
   FOR EACH ROW

DECLARE
   v_username varchar2(10);

BEGIN

   -- Find username of person performing INSERT into table
   SELECT user INTO v_username
   FROM dual;

   -- Update create_date field to current system date
   :new.create_date := sysdate;

   -- Update created_by field to the username of the person performing the INSERT
   :new.created_by := v_username;

END;
/

```



