### PR TITLE
Bug Fix: All non-sql scripts being ignored by .WithScriptsAndCodeEmbeddedInAssembly

### DIFF
--- a/src/dbup-core/Builder/StandardExtensions.cs
+++ b/src/dbup-core/Builder/StandardExtensions.cs
@@ -376,7 +376,7 @@ public static class StandardExtensions
     /// </returns>
     public static UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this UpgradeEngineBuilder builder, Assembly assembly)
     {
-        return WithScripts(builder, new EmbeddedScriptAndCodeProvider(assembly, s => s.EndsWith(".sql", StringComparison.OrdinalIgnoreCase)));
+        return WithScripts(builder, new EmbeddedScriptAndCodeProvider(assembly, s => true));
     }
 
     /// <summary>


### PR DESCRIPTION
I recently upgraded DbUp from 3.3.5 to 4.1.0. After this, all scripts using IScript were ignored. looking at the code there is a filter applied to WithScriptsAndCodeEmbeddedInAssembly that restricts them to only ending in ".sql", which seems contradictory to the method's intended purpose.

I've removed the default filter with an expression that returns true for all, believing that if a filter is desired it can be entered using the filter parameter.

I think this is somehow related to https://github.com/DbUp/DbUp/issues/213 and its implications didn't quite make it into the documentation.