### PR TITLE
Correct behaviour of WithScriptsAndCodeEmbeddedInAssembly helper

### DIFF
--- a/src/dbup-core/Builder/StandardExtensions.cs
+++ b/src/dbup-core/Builder/StandardExtensions.cs
@@ -376,7 +376,7 @@ public static class StandardExtensions
     /// </returns>
     public static UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this UpgradeEngineBuilder builder, Assembly assembly)
     {
-        return WithScripts(builder, new EmbeddedScriptAndCodeProvider(assembly, s => s.EndsWith(".sql", StringComparison.OrdinalIgnoreCase)));
+        return WithScripts(builder, new EmbeddedScriptAndCodeProvider(assembly, s => s.EndsWith(".sql", StringComparison.OrdinalIgnoreCase), s => true));
     }
 
     /// <summary>
@@ -391,6 +391,21 @@ public static class StandardExtensions
     public static UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this UpgradeEngineBuilder builder, Assembly assembly, Func<string, bool> filter)
     {
         return WithScripts(builder, new EmbeddedScriptAndCodeProvider(assembly, filter));
+    }
+    
+    /// <summary>
+    /// Adds all scripts found as embedded resources in the given assembly, or classes which inherit from IScript, with a custom filter (you'll need to exclude non- .SQL files yourself).
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="assembly">The assembly.</param>
+    /// <param name="filter">The script filter. Don't forget to ignore any non- .SQL files.</param>
+    /// <param name="codeScriptFilter">The embedded script filter.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this UpgradeEngineBuilder builder, Assembly assembly, Func<string, bool> filter, Func<string, bool> codeScriptFilter)
+    {
+        return WithScripts(builder, new EmbeddedScriptAndCodeProvider(assembly, filter, codeScriptFilter));
     }
 
     /// <summary>

--- a/src/dbup-core/ScriptProviders/EmbeddedScriptAndCodeProvider.cs
+++ b/src/dbup-core/ScriptProviders/EmbeddedScriptAndCodeProvider.cs
@@ -20,11 +20,22 @@ namespace DbUp.ScriptProviders
         /// Initializes a new instance of the <see cref="EmbeddedScriptProvider"/> class.
         /// </summary>
         /// <param name="assembly">The assembly.</param>
-        /// <param name="filter">The embedded script filter.</param>
+        /// <param name="filter">The embedded script and code file filter.</param>
         public EmbeddedScriptAndCodeProvider(Assembly assembly, Func<string, bool> filter)
+            : this(assembly, filter, filter)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmbeddedScriptProvider"/> class.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="filter">The embedded script filter.</param>
+        /// <param name="codeScriptFilter">The embedded script filter. If null, filter is used.</param>
+        public EmbeddedScriptAndCodeProvider(Assembly assembly, Func<string, bool> filter, Func<string, bool> codeScriptFilter)
         {
             this.assembly = assembly;
-            this.filter = filter;
+            this.filter = codeScriptFilter;
             embeddedScriptProvider = new EmbeddedScriptProvider(assembly, filter);
         }
 


### PR DESCRIPTION
Changed `WithScriptsAndCodeEmbeddedInAssembly` helper method to not filter code script just like it did in `3.5`. Kept compatibility for those already specifying a custom filter. Fixes #347