### PR TITLE
Create/Drop Firebird databases (issue #362)

### DIFF
--- a/src/dbup-firebird/FirebirdConnectionManager.cs
+++ b/src/dbup-firebird/FirebirdConnectionManager.cs
@@ -1,8 +1,7 @@
 ﻿using DbUp.Engine.Transactions;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
 using FirebirdSql.Data.FirebirdClient;
+using FirebirdSql.Data.Isql;
+using System.Collections.Generic;
 
 namespace DbUp.Firebird
 {
@@ -25,14 +24,15 @@ namespace DbUp.Firebird
         /// <param name="scriptContents">The contents of the script to split.</param>
         public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
         {
-            //TODO: Possible Change - this is the PostGres version
-            var scriptStatements =
-                Regex.Split(scriptContents, "^\\s*;\\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline)
-                    .Select(x => x.Trim())
-                    .Where(x => x.Length > 0)
-                    .ToArray();
+            var statements = new List<string>();
 
-            return scriptStatements;
+            var script = new FbScript(scriptContents);
+            script.Parse();
+            
+            foreach (FbStatement stmt in script.Results)
+                statements.Add(stmt.Text);
+
+            return statements.ToArray();
         }
     }
 }

--- a/src/dbup-firebird/FirebirdExtensions.cs
+++ b/src/dbup-firebird/FirebirdExtensions.cs
@@ -5,7 +5,6 @@ using DbUp;
 using DbUp.Engine.Output;
 using FirebirdSql.Data.FirebirdClient;
 using System.IO;
-using System;
 
 // ReSharper disable once CheckNamespace
 
@@ -50,7 +49,7 @@ public static class FirebirdExtensions
         var builder = new UpgradeEngineBuilder();
         builder.Configure(c => c.ConnectionManager = connectionManager);
         builder.Configure(c => c.ScriptExecutor = new FirebirdScriptExecutor(() => c.ConnectionManager, () => c.Log, null, () => c.VariablesEnabled, c.ScriptPreprocessors, () => c.Journal));
-        builder.Configure(c => c.Journal = new FirebirdTableJournal(() => c.ConnectionManager, () => c.Log, "schemaversions"));
+        builder.Configure(c => c.Journal = new FirebirdTableJournal(() => c.ConnectionManager, () => c.Log, "SchemaVersions"));
         builder.WithPreprocessor(new FirebirdPreprocessor());
         return builder;
     }

--- a/src/dbup-firebird/dbup-firebird.csproj
+++ b/src/dbup-firebird/dbup-firebird.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
-    <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="4.5.2.0" />
+    <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.0.0" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Implements DropDatabase and EnsureDatabase in the dpup-firebird project #362.
`DropDatabase.For.FirebirdDatabase(connectionString);
EnsureDatabase.For.FirebirdDatabase(connectionString);`

Replaced the code copied from Postgres to split a script with a Firebird specific one as mentioned in #159.

Use unquoted table name for schemaversions table, in the generator and the trigger, they were inconsistent before.

`DoesTableExistSql()` fixed (see #248 and #250). Firebird uses all uppercase for database objects unless they are quoted. Per above changed to unquoted names and using an UPPER(tablename) in the DoesTableExistSQL().