### PR TITLE
Better parsing of double quoted texts.

### DIFF
--- a/src/dbup-core/Support/SqlParser.cs
+++ b/src/dbup-core/Support/SqlParser.cs
@@ -12,6 +12,7 @@ namespace DbUp.Support
         private const char EndOfLineChar = '\n';
         private const char CarriageReturn = '\r';
         private const char SingleQuoteChar = (char)39;
+        private const char DoubleQuoteChar = '"';
         private const char DashChar = '-';
         private const char SlashChar = '/';
         private const char StarChar = '*';
@@ -66,7 +67,7 @@ namespace DbUp.Support
                 {
                     ReadCustomStatement();
                 }
-                else if (IsQuote)
+                else if (IsQuote || IsDoubleQuote)
                 {
                     ReadQuotedString();
                 }
@@ -290,6 +291,14 @@ namespace DbUp.Support
             return true;
         }
 
+        private bool IsDoubleQuote
+        {
+            get
+            {
+                return CurrentChar == DoubleQuoteChar;
+            }
+        }
+
         private bool IsBeginningOfBracketedText
         {
             get
@@ -355,6 +364,7 @@ namespace DbUp.Support
         /// </summary>
         private void ReadQuotedString()
         {
+            var quoteChar = CurrentChar;
             ReadCharacter(CharacterType.QuotedString, CurrentChar);
             while (Read() != FailedRead)
             {
@@ -364,7 +374,7 @@ namespace DbUp.Support
                     Read();
                 }
                 ReadCharacter(CharacterType.QuotedString, CurrentChar);
-                if (IsQuote)
+                if (CurrentChar == quoteChar)
                 {
                     return;
                 }
@@ -514,7 +524,7 @@ namespace DbUp.Support
             Delimiter,
             /// <summary>Character is a custom statement (open for new implementation)</summary>
             CustomStatement,
-            
+
         }
     }
 }

--- a/src/dbup-tests/Engine/VariableSubstitutionPreprocessorTests.cs
+++ b/src/dbup-tests/Engine/VariableSubstitutionPreprocessorTests.cs
@@ -36,6 +36,27 @@ namespace DbUp.Tests.Engine
         }
 
         [Fact]
+        public void substitutes_variables_when_quoted_text_contains_comment_sequence()
+        {
+            // This is a specific use case from GitHub issue #351
+            var journal = Substitute.For<IJournal>();
+            var connection = Substitute.For<IDbConnection>();
+            var command = Substitute.For<IDbCommand>();
+            connection.CreateCommand().Returns(command);
+
+            var upgradeEngine = DeployChanges.To
+                .SqlDatabase(new SubstitutedConnectionConnectionManager(connection), "Db")
+                .WithScript("testscript", "SELECT 'Test' AS \"/*\"\r\nGO\r\n$somevar$")
+                .JournalTo(journal)
+                .WithVariable("somevar", "coriander")
+                .Build();
+
+            upgradeEngine.PerformUpgrade();
+
+            command.CommandText.ShouldBe("SELECT 'Test' AS \"/*\"\r\nGO\r\ncoriander");
+        }
+
+        [Fact]
         public void substitutes_variables_in_quoted_text()
         {
             var journal = Substitute.For<IJournal>();
@@ -74,7 +95,7 @@ namespace DbUp.Tests.Engine
 
             command.CommandText.ShouldBe("/*$somevar$*/");
         }
-        
+
         [Fact]
         public void ignores_undefined_variables_in_complex_comments()
         {
@@ -136,7 +157,7 @@ namespace DbUp.Tests.Engine
             result.Successful.ShouldBeFalse();
             result.Error.ShouldBeOfType<InvalidOperationException>();
         }
-        
+
         [Fact]
         public void ignores_if_whitespace_between_dollars()
         {
@@ -157,7 +178,7 @@ namespace DbUp.Tests.Engine
             result.Successful.ShouldBeTrue();
             command.CommandText.ShouldBe("$some var$");
         }
-        
+
         [Fact]
         public void ignores_if_newline_between_dollars()
         {


### PR DESCRIPTION
This should resolve #351 by supporting double quoted strings in the same manner as single quoted strings. It may be that IsDoubleQuote should be a protected member, but that throws out the API tests for changes to the public signature.