### PR TITLE
Prevents interactive reporting for assent

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,3 +13,6 @@ skip_tags: true
 
 cache:
   - src\packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
+
+environment:
+  AssentNonInteractive: true


### PR DESCRIPTION
Currently our builds are failing due to Assent attempting to spin up a reporting tool like beyond compare or KDiff. 

Looking at this: https://github.com/droyad/Assent#automated-builds looks like setting an environment variable should allow builds to proceed.