### PR TITLE
SqlServer ensuring database

### DIFF
--- a/src/dbup-sqlserver/SqlServerExtensions.cs
+++ b/src/dbup-sqlserver/SqlServerExtensions.cs
@@ -223,35 +223,28 @@ public static class SqlServerExtensions
         string masterConnectionString;
         GetMasterConnectionStringBuilder(connectionString, logger, out masterConnectionString, out databaseName);
 
+        try
+        {
+            using (var connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+                if (DatabaseExists(connection, databaseName))
+                    return;
+            }
+        }
+        catch (Exception e)
+        {
+            logger.WriteInformation(@"Database not found on server with connection string in settings: {0}", e.Message);
+        }
+
         using (var connection = new SqlConnection(masterConnectionString))
         {
             connection.Open();
-
-            var sqlCommandText = string.Format
-                (
-                    @"SELECT TOP 1 case WHEN dbid IS NOT NULL THEN 1 ELSE 0 end FROM sys.sysdatabases WHERE name = '{0}';",
-                    databaseName
-                );
-
-
-            // check to see if the database already exists..
-            using (var command = new SqlCommand(sqlCommandText, connection)
-            {
-                CommandType = CommandType.Text
-            })
-
-            {
-                var results = (int?) command.ExecuteScalar();
-
-                // if the database exists, we're done here...
-                if (results.HasValue && results.Value == 1)
-                {
-                    return;
-                }
-            }
+            if (DatabaseExists(connection, databaseName))
+                return;
 
             string collationString = string.IsNullOrEmpty(collation) ? "" : string.Format(@" COLLATE {0}", collation);
-            sqlCommandText = string.Format
+            var sqlCommandText = string.Format
                     (
                         @"create database [{0}]{1};",
                         databaseName,
@@ -284,7 +277,6 @@ public static class SqlServerExtensions
                 }
 
                 command.ExecuteNonQuery();
-
             }
 
             logger.WriteInformation(@"Created database {0}", databaseName);
@@ -331,16 +323,8 @@ public static class SqlServerExtensions
         using (var connection = new SqlConnection(masterConnectionString))
         {
             connection.Open();
-            var databaseExistCommand = new SqlCommand($"SELECT TOP 1 case WHEN dbid IS NOT NULL THEN 1 ELSE 0 end FROM sys.sysdatabases WHERE name = '{databaseName}';", connection)
-            {
-                CommandType = CommandType.Text
-            };
-            using (var command = databaseExistCommand)
-            {
-                var exists = (int?)command.ExecuteScalar();
-                if (!exists.HasValue)
-                    return;
-            }
+            if (!DatabaseExists(connection, databaseName))
+                return;
 
             var dropDatabaseCommand = new SqlCommand($"ALTER DATABASE [{databaseName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [{databaseName}];", connection) { CommandType = CommandType.Text };
             using (var command = dropDatabaseCommand)
@@ -374,5 +358,29 @@ public static class SqlServerExtensions
 
         logger.WriteInformation("Master ConnectionString => {0}", logMasterConnectionStringBuilder.ConnectionString);
         masterConnectionString = masterConnectionStringBuilder.ConnectionString;
+    }
+
+    private static bool DatabaseExists(SqlConnection connection, string databaseName)
+    {
+        var sqlCommandText = string.Format
+        (
+            @"SELECT TOP 1 case WHEN dbid IS NOT NULL THEN 1 ELSE 0 end FROM sys.sysdatabases WHERE name = '{0}';",
+            databaseName
+        );
+
+        // check to see if the database already exists..
+        using (var command = new SqlCommand(sqlCommandText, connection)
+        {
+            CommandType = CommandType.Text
+        })
+
+        {
+            var results = (int?)command.ExecuteScalar();
+
+            if (results.HasValue && results.Value == 1)
+                return true;
+            else
+                return false;
+        }
     }
 }


### PR DESCRIPTION
There is a possibility in MSSQL server to set authentication on database level which caused some problems with ensuring database.
In this event user pointed in connection string can only access database pointed in connection string, and CANN'T reach MASTER database.
And this is a bit illogical, because the database itself is reachable but it fails due to the fact it cann't reach master database.