### PR TITLE
Fix error when using abstract code-based script

### DIFF
--- a/src/dbup-core/ScriptProviders/EmbeddedScriptAndCodeProvider.cs
+++ b/src/dbup-core/ScriptProviders/EmbeddedScriptAndCodeProvider.cs
@@ -73,9 +73,11 @@ namespace DbUp.ScriptProviders
                 {
                     return script.IsAssignableFrom(type) &&
 #if USE_TYPE_INFO
-                        type.GetTypeInfo().IsClass;
+                        type.GetTypeInfo().IsClass &&
+                       !type.GetTypeInfo().IsAbstract;
 #else
-                        type.IsClass;
+                        type.IsClass &&
+                       !type.IsAbstract;
 #endif
                 })
                 .Select(s => (SqlScript) new LazySqlScript(s.FullName + ".cs", this.sqlScriptOptions, () => ((IScript) Activator.CreateInstance(s)).ProvideScript(dbCommandFactory)))

--- a/src/dbup-tests/ScriptProvider/EmbeddedScriptAndCodeProviderTests.cs
+++ b/src/dbup-tests/ScriptProvider/EmbeddedScriptAndCodeProviderTests.cs
@@ -36,7 +36,17 @@ namespace DbUp.Tests.ScriptProvider
             [Then]
             public void it_should_return_all_sql_files()
             {
-                scriptsToExecute.Length.ShouldBe(10);
+                scriptsToExecute
+                    .Count(s => s.Name.EndsWith(".sql"))
+                    .ShouldBe(9);
+            }
+
+            [Then]
+            public void should_ignore_abstract_implementations()
+            {
+                scriptsToExecute
+                    .Where(s => s.Name.EndsWith("Script20120723_1_Test4_Base.cs"))
+                    .ShouldBeEmpty();
             }
 
             [Then]

--- a/src/dbup-tests/TestScripts/Script20120723_1_Test4.cs
+++ b/src/dbup-tests/TestScripts/Script20120723_1_Test4.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Data;
+using Castle.DynamicProxy.Generators.Emitters;
 using DbUp.Engine;
 
 namespace DbUp.Tests.TestScripts
 {
-    public class Script20120723_1_Test4 : IScript
+    public class Script20120723_1_Test4 : Script20120723_1_Test4_Base
     {
-        public string ProvideScript(Func<IDbCommand> commandFactory)
+        protected override string ProvideScriptImplementation(Func<IDbCommand> commandFactory)
         {
             return "test4";
         }

--- a/src/dbup-tests/TestScripts/Script20120723_1_Test4_Base.cs
+++ b/src/dbup-tests/TestScripts/Script20120723_1_Test4_Base.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Data;
+using Castle.DynamicProxy.Generators.Emitters;
+using DbUp.Engine;
+
+namespace DbUp.Tests.TestScripts
+{
+    public abstract class Script20120723_1_Test4_Base : IScript
+    {
+        public string ProvideScript(Func<IDbCommand> commandFactory)
+        {
+            return ProvideScriptImplementation(commandFactory);
+        }
+
+        protected abstract string ProvideScriptImplementation(Func<IDbCommand> commandFactory);
+    }
+}


### PR DESCRIPTION
* Fixes an issue in `EmbeddedScriptAndCodeProvider` where an exception would be thrown if any `abstract` class implemented `IScript` (error was `MissingMethodException: Cannot create an abstract class`)