### PR TITLE
Consistent console color reset

### DIFF
--- a/src/dbup-core/Engine/Output/AutodetectUpgradeLog.cs
+++ b/src/dbup-core/Engine/Output/AutodetectUpgradeLog.cs
@@ -31,9 +31,16 @@ namespace DbUp.Engine.Output
                 }
             }
 
+            var oldColor = Console.ForegroundColor;
             Console.ForegroundColor = GetColor();
-            Console.WriteLine(format(), args);
-            Console.ResetColor();
+            try
+            {
+                Console.WriteLine(format(), args);
+            }
+            finally
+            {
+                Console.ForegroundColor = oldColor;
+            }
             return true;
         }
     }

--- a/src/dbup-core/Engine/Output/ConsoleUpgradeLog.cs
+++ b/src/dbup-core/Engine/Output/ConsoleUpgradeLog.cs
@@ -39,9 +39,16 @@ namespace DbUp.Engine.Output
 
         private static void Write(ConsoleColor color, string format, object[] args)
         {
+            var oldColor = Console.ForegroundColor;
             Console.ForegroundColor = color;
-            Console.WriteLine(format, args);
-            Console.ResetColor();
+            try
+            {
+                Console.WriteLine(format, args);
+            }
+            finally
+            {
+                Console.ForegroundColor = oldColor;
+            }
         }
     }
 }

--- a/src/dbup-core/Engine/Output/MultipleUpgradeLog.cs
+++ b/src/dbup-core/Engine/Output/MultipleUpgradeLog.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 
 namespace DbUp.Engine.Output
 {
@@ -19,7 +18,7 @@ namespace DbUp.Engine.Output
 
         public void WriteInformation(string format, params object[] args)
         {
-            foreach(var log in upgradeLogs)
+            foreach (var log in upgradeLogs)
                 log.WriteInformation(format, args);
         }
 


### PR DESCRIPTION
Correct setting of the color of console symbols. Now the error in the output does not lead to the fact that the color that was previously exposed remains.