### PR TITLE
DbCommandFactory: create DbCommand with committed transaction

### DIFF
--- a/src/dbup-core/ScriptProviders/EmbeddedScriptAndCodeProvider.cs
+++ b/src/dbup-core/ScriptProviders/EmbeddedScriptAndCodeProvider.cs
@@ -66,18 +66,18 @@ public class EmbeddedScriptAndCodeProvider : IScriptProvider
     IEnumerable<SqlScript> ScriptsFromScriptClasses(IConnectionManager connectionManager)
     {
         var script = typeof(IScript);
-            return assembly
+        return  assembly
             .GetTypes()
             .Where(type => script.IsAssignableFrom(type) &&
                            type.IsClass &&
                            !type.IsAbstract
             )
-                .Select(s => (SqlScript)new LazySqlScript(s.FullName + ".cs", sqlScriptOptions, () =>
+            .Select(s => (SqlScript)new LazySqlScript(s.FullName + ".cs", sqlScriptOptions, () =>
                 connectionManager.ExecuteCommandsWithManagedConnection(
                     dbCommandFactory =>
-                                        ((IScript)Activator.CreateInstance(s))
-                                        .ProvideScript(dbCommandFactory)))
-                ).ToList();
+                        ((IScript)Activator.CreateInstance(s))
+                        .ProvideScript(dbCommandFactory)))
+            ).ToList();
     }
 
     /// <summary>

--- a/src/dbup-core/ScriptProviders/ScriptInstanceProvider.cs
+++ b/src/dbup-core/ScriptProviders/ScriptInstanceProvider.cs
@@ -26,7 +26,8 @@ class ScriptInstanceProvider : IScriptProvider
     /// </summary>
     /// <param name="scripts">The IScript instances to include</param>
     /// <param name="namer">A function that returns the name of the script</param>
-    public ScriptInstanceProvider(Func<IScript, string> namer, params IScript[] scripts) : this(namer, new SqlScriptOptions(), scripts)
+    public ScriptInstanceProvider(Func<IScript, string> namer, params IScript[] scripts) : this(namer,
+        new SqlScriptOptions(), scripts)
     {
     }
 
@@ -36,7 +37,8 @@ class ScriptInstanceProvider : IScriptProvider
     /// <param name="scripts">The IScript instances to include</param>
     /// <param name="namer">A function that returns the name of the script</param>
     /// <param name="sqlScriptOptions">The sql script options.</param>
-    public ScriptInstanceProvider(Func<IScript, string> namer, SqlScriptOptions sqlScriptOptions, params IScript[] scripts)
+    public ScriptInstanceProvider(Func<IScript, string> namer, SqlScriptOptions sqlScriptOptions,
+        params IScript[] scripts)
     {
         this.scripts = scripts;
         this.namer = namer ?? throw new ArgumentNullException(nameof(namer));
@@ -45,10 +47,13 @@ class ScriptInstanceProvider : IScriptProvider
 
     public IEnumerable<SqlScript> GetScripts(IConnectionManager connectionManager)
     {
-        return connectionManager.ExecuteCommandsWithManagedConnection(
-            dbCommandFactory => scripts
-                .Select(s => new LazySqlScript(namer(s), sqlScriptOptions, () => s.ProvideScript(dbCommandFactory)))
-                .ToArray()
-        );
+        return scripts
+            .Select(s => new LazySqlScript(
+                    namer(s),
+                    sqlScriptOptions,
+                    () => connectionManager.ExecuteCommandsWithManagedConnection(s.ProvideScript)
+                )
+            )
+            .ToArray();
     }
 }

--- a/src/dbup-tests/ApprovalFiles/TransactionScenarios.UsingTransactionPerScriptScenarioSuccess.approved.txt
+++ b/src/dbup-tests/ApprovalFiles/TransactionScenarios.UsingTransactionPerScriptScenarioSuccess.approved.txt
@@ -1,6 +1,9 @@
 DB Operation: Open connection
 Info:         Beginning database upgrade
 DB Operation: Begin transaction
+DB Operation: Commit transaction
+DB Operation: Dispose transaction
+DB Operation: Begin transaction
 DB Operation: Execute non query command: IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = N'dbo') Exec('CREATE SCHEMA [dbo]')
 DB Operation: Dispose command
 DB Operation: Commit transaction
@@ -16,6 +19,15 @@ Info:         Executing Database Server script 'Script0002.sql'
 DB Operation: Begin transaction
 Info:         Ensuring tables exists and is latest version
 DB Operation: Execute non query command: print 'script2'
+DB Operation: Dispose command
+DB Operation: Commit transaction
+DB Operation: Dispose transaction
+Info:         Running script in ProvideScript method
+DB Operation: Execute scalar command: select 1
+Info:         Executing Database Server script 'ScriptWithChangeInProvideScriptMethod'
+DB Operation: Begin transaction
+Info:         Ensuring tables exists and is latest version
+DB Operation: Execute non query command: 
 DB Operation: Dispose command
 DB Operation: Commit transaction
 DB Operation: Dispose transaction

--- a/src/dbup-tests/ApprovalFiles/TransactionScenarios.UsingTransactionPerScriptScenarioSuccess.approved.txt
+++ b/src/dbup-tests/ApprovalFiles/TransactionScenarios.UsingTransactionPerScriptScenarioSuccess.approved.txt
@@ -1,9 +1,6 @@
 DB Operation: Open connection
 Info:         Beginning database upgrade
 DB Operation: Begin transaction
-DB Operation: Commit transaction
-DB Operation: Dispose transaction
-DB Operation: Begin transaction
 DB Operation: Execute non query command: IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = N'dbo') Exec('CREATE SCHEMA [dbo]')
 DB Operation: Dispose command
 DB Operation: Commit transaction
@@ -22,8 +19,11 @@ DB Operation: Execute non query command: print 'script2'
 DB Operation: Dispose command
 DB Operation: Commit transaction
 DB Operation: Dispose transaction
+DB Operation: Begin transaction
 Info:         Running script in ProvideScript method
 DB Operation: Execute scalar command: select 1
+DB Operation: Commit transaction
+DB Operation: Dispose transaction
 Info:         Executing Database Server script 'ScriptWithChangeInProvideScriptMethod'
 DB Operation: Begin transaction
 Info:         Ensuring tables exists and is latest version

--- a/src/dbup-tests/ApprovalFiles/TransactionScenarios.UsingTransactionPerScriptWithCodeScriptScenario.approved.txt
+++ b/src/dbup-tests/ApprovalFiles/TransactionScenarios.UsingTransactionPerScriptWithCodeScriptScenario.approved.txt
@@ -1,24 +1,21 @@
 DB Operation: Open connection
-Info:         Beginning transaction
-DB Operation: Begin transaction
 Info:         Beginning database upgrade
+DB Operation: Begin transaction
+DB Operation: Commit transaction
+DB Operation: Dispose transaction
+DB Operation: Begin transaction
 DB Operation: Execute non query command: IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = N'dbo') Exec('CREATE SCHEMA [dbo]')
 DB Operation: Dispose command
-Info:         Executing Database Server script 'Script0001.sql'
-Info:         Ensuring tables exists and is latest version
-DB Operation: Execute non query command: print 'script1'
-DB Operation: Dispose command
-Info:         Executing Database Server script 'Script0002.sql'
-Info:         Ensuring tables exists and is latest version
-DB Operation: Execute non query command: print 'script2'
-DB Operation: Dispose command
+DB Operation: Commit transaction
+DB Operation: Dispose transaction
 Info:         Running script in ProvideScript method
 DB Operation: Execute scalar command: select 1
 Info:         Executing Database Server script 'ScriptWithChangeInProvideScriptMethod'
+DB Operation: Begin transaction
 Info:         Ensuring tables exists and is latest version
 DB Operation: Execute non query command: 
 DB Operation: Dispose command
-Info:         Upgrade successful
 DB Operation: Commit transaction
 DB Operation: Dispose transaction
+Info:         Upgrade successful
 DB Operation: Dispose connection

--- a/src/dbup-tests/ApprovalFiles/TransactionScenarios.UsingTransactionPerScriptWithCodeScriptScenario.approved.txt
+++ b/src/dbup-tests/ApprovalFiles/TransactionScenarios.UsingTransactionPerScriptWithCodeScriptScenario.approved.txt
@@ -1,15 +1,15 @@
 DB Operation: Open connection
 Info:         Beginning database upgrade
 DB Operation: Begin transaction
-DB Operation: Commit transaction
-DB Operation: Dispose transaction
-DB Operation: Begin transaction
 DB Operation: Execute non query command: IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = N'dbo') Exec('CREATE SCHEMA [dbo]')
 DB Operation: Dispose command
 DB Operation: Commit transaction
 DB Operation: Dispose transaction
+DB Operation: Begin transaction
 Info:         Running script in ProvideScript method
 DB Operation: Execute scalar command: select 1
+DB Operation: Commit transaction
+DB Operation: Dispose transaction
 Info:         Executing Database Server script 'ScriptWithChangeInProvideScriptMethod'
 DB Operation: Begin transaction
 Info:         Ensuring tables exists and is latest version

--- a/src/dbup-tests/ScriptProvider/EmbeddedScriptAndCodeProviderTests.cs
+++ b/src/dbup-tests/ScriptProvider/EmbeddedScriptAndCodeProviderTests.cs
@@ -81,11 +81,5 @@ public class EmbeddedScriptAndCodeProviderTests
         {
             scriptsToExecute.ShouldNotContain(x => x.Name.Contains("Test4"));
         }
-
-        [Then]
-        public void it_should_only_return_the_sql_scripts()
-        {
-            scriptsToExecute.Length.ShouldBe(9);
-        }
     }
 }


### PR DESCRIPTION
This should fix  DbUp/DbUp#801 bug with committed transaction for LazySqlScript when `Dbcommand` is created through ` DbCommandFactory` inside code scripts.