### PR TITLE
Fix Nested Multiline Comment Parsing by SqlParser

### DIFF
--- a/src/dbup-core/Support/SqlParser.cs
+++ b/src/dbup-core/Support/SqlParser.cs
@@ -363,8 +363,12 @@ namespace DbUp.Support
 
         void ReadSlashStarComment()
         {
-            // Write the current slash.
+            // We have entered this method because we've identified the "/*" pattern.
+            // Write both characters here as technically they go together as a token.
             ReadCharacter(CharacterType.SlashStarComment, CurrentChar);
+            Read();
+            ReadCharacter(CharacterType.SlashStarComment, CurrentChar);
+
             // Read until we find a the ending of the slash star comment,
             // Or a nested slash star comment.
             while (Read() != FailedRead)
@@ -372,6 +376,7 @@ namespace DbUp.Support
                 // Try to get out of the comment straight away
                 if (IsEndOfSlashStarComment)
                 {
+                    // Write both characters of the "*/" token immediately then return
                     ReadCharacter(CharacterType.SlashStarComment, CurrentChar);
                     Read();
                     ReadCharacter(CharacterType.SlashStarComment, CurrentChar);
@@ -380,7 +385,7 @@ namespace DbUp.Support
 
                 if (IsBeginningOfSlashStarComment)
                 {
-                    // Nested comment found - using recursive call to read it.
+                    // Nested comment found - using recursive call to read it then continue the loop.
                     ReadSlashStarComment();
                     continue;
                 }

--- a/src/dbup-core/Support/SqlParser.cs
+++ b/src/dbup-core/Support/SqlParser.cs
@@ -279,15 +279,14 @@ namespace DbUp.Support
             {
                 var lastCharIsNullOrEmpty = char.IsWhiteSpace(LastChar) || LastChar == NullChar || !DelimiterRequiresWhitespace;
                 var isCurrentCharacterStartOfDelimiter = IsCurrentCharEqualTo(Delimiter[0]);
-                return
-                    lastCharIsNullOrEmpty &&
-                    isCurrentCharacterStartOfDelimiter &&
-                    TryPeek(Delimiter.Length - 1, out var result) &&
-                    string.Equals(result, Delimiter.Substring(1), StringComparison.OrdinalIgnoreCase);
+                return lastCharIsNullOrEmpty
+                       && isCurrentCharacterStartOfDelimiter
+                       && TryPeek(Delimiter.Length - 1, out var result)
+                       && string.Equals(result, Delimiter.Substring(1), StringComparison.OrdinalIgnoreCase);
             }
         }
 
-        bool IsEndOfSlashStarComment => LastChar == StarChar && CurrentChar == SlashChar;
+        bool IsEndOfSlashStarComment => CurrentChar == StarChar && Peek() == SlashChar;
 
 
         /// <summary>
@@ -370,19 +369,23 @@ namespace DbUp.Support
             // Or a nested slash star comment.
             while (Read() != FailedRead)
             {
+                // Try to get out of the comment straight away
+                if (IsEndOfSlashStarComment)
+                {
+                    ReadCharacter(CharacterType.SlashStarComment, CurrentChar);
+                    Read();
+                    ReadCharacter(CharacterType.SlashStarComment, CurrentChar);
+                    return;
+                }
+
                 if (IsBeginningOfSlashStarComment)
                 {
                     // Nested comment found - using recursive call to read it.
                     ReadSlashStarComment();
+                    continue;
                 }
-                else
-                {
-                    ReadCharacter(CharacterType.SlashStarComment, CurrentChar);
-                    if (IsEndOfSlashStarComment)
-                    {
-                        return;
-                    }
-                }
+
+                ReadCharacter(CharacterType.SlashStarComment, CurrentChar);
             }
         }
 

--- a/src/dbup-tests/Support/SqlServer/SqlParserTests.cs
+++ b/src/dbup-tests/Support/SqlServer/SqlParserTests.cs
@@ -16,19 +16,25 @@ go
 DELIMITERION;
 go;
 DELIMITER";
-            var parser = new TestSqlParser(originalSql, "DELIMITER");
-            var parsedSql = parser.ParseStuff();
-            parsedSql.ShouldBe(originalSql);
+            using (var parser = new TestSqlParser(originalSql, "DELIMITER"))
+            {
+                var parsedSql = parser.ParseStuff();
+                parsedSql.ShouldBe(originalSql);
+            }
         }
+
         [Fact]
         public void should_handle_delimiter_at_the_eof()
         {
             var originalSql = @"something
 go";
-            var parser = new TestSqlParser(originalSql);
-            var parsedSql = parser.ParseStuff();
-            parsedSql.ShouldBe(originalSql);
+            using (var parser = new TestSqlParser(originalSql))
+            {
+                var parsedSql = parser.ParseStuff();
+                parsedSql.ShouldBe(originalSql);
+            }
         }
+
         [Fact]
         public void shouldnt_change_parsed_script()
         {
@@ -40,9 +46,11 @@ Someotherstuff
 gogogo this shouldnt match
 ;
 go";
-            var parser = new TestSqlParser(originalSql);
-            var parsedSql = parser.ParseStuff();
-            parsedSql.ShouldBe(originalSql);
+            using (var parser = new TestSqlParser(originalSql))
+            {
+                var parsedSql = parser.ParseStuff();
+                parsedSql.ShouldBe(originalSql);
+            }
         }
 
         class TestSqlParser : SqlParser


### PR DESCRIPTION
When the SqlParser encountered a nested multiline comment that had the
closing comment delimeters together in sequence it would fail to
properly parse.

Given the example:
```sql
    /*ab/*cd*/*/
```
The SqlParser correctly identifies the second multiline comment
(i.e. `cd`) it then advances until the `/` character which closes the
inner comment (10th character in the string). At this character, the
parser properties were looking forward and seeing `/*` but also looking
backwards and seeing `*/`. Because the check for the start of another
nested comment was checked first it would be read as the start of
another multiline comment.

Similar to the nested multiline comments where closing tokens came
one-after-the-other, the opening tokens could also be confused.

This PR resolves the issue by changing the end multiline comment to
be detected by looking forward. Then, when either the start or end
of the multiline comment is detected both characters of the token are
immediately processed.

Fixes #439