### PR TITLE
Add script discovery methods

### DIFF
--- a/src/dbup-core/Engine/UpgradeEngine.cs
+++ b/src/dbup-core/Engine/UpgradeEngine.cs
@@ -113,9 +113,24 @@ namespace DbUp.Engine
             }
         }
 
+        public List<string> GetExecutedButNotDiscoveredScripts()
+        {
+            return GetExecutedScripts().Except(GetDiscoveredScriptsAsEnumerable().Select(x => x.Name)).ToList();
+        }
+
+        public List<SqlScript> GetDiscoveredScripts()
+        {
+            return GetDiscoveredScriptsAsEnumerable().ToList();
+        }
+
+        IEnumerable<SqlScript> GetDiscoveredScriptsAsEnumerable()
+        {
+            return configuration.ScriptProviders.SelectMany(scriptProvider => scriptProvider.GetScripts(configuration.ConnectionManager));
+        }
+
         List<SqlScript> GetScriptsToExecuteInsideOperation()
         {
-            var allScripts = configuration.ScriptProviders.SelectMany(scriptProvider => scriptProvider.GetScripts(configuration.ConnectionManager));
+            var allScripts = GetDiscoveredScriptsAsEnumerable();
             var executedScriptNames = new HashSet<string>(configuration.Journal.GetExecutedScripts());
 
             var sorted = allScripts.OrderBy(s => s.SqlScriptOptions.RunGroupOrder).ThenBy(s => s.Name, configuration.ScriptNameComparer);

--- a/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
@@ -215,6 +215,8 @@ namespace DbUp.Engine
     {
         public UpgradeEngine(DbUp.Builder.UpgradeConfiguration configuration) { }
         public event System.EventHandler ScriptExecuted;
+        public System.Collections.Generic.List<DbUp.Engine.SqlScript> GetDiscoveredScripts() { }
+        public System.Collections.Generic.List<string> GetExecutedButNotDiscoveredScripts() { }
         public System.Collections.Generic.List<string> GetExecutedScripts() { }
         public System.Collections.Generic.List<DbUp.Engine.SqlScript> GetScriptsToExecute() { }
         public bool IsUpgradeRequired() { }

--- a/src/dbup-tests/Engine/UpgradeEngineTests.cs
+++ b/src/dbup-tests/Engine/UpgradeEngineTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using DbUp.Builder;
 using DbUp.Engine;
 using DbUp.Engine.Output;
@@ -96,6 +97,87 @@ namespace DbUp.Tests.Engine
             public void the_scripts_are_not_run()
             {
                 scriptExecutor.DidNotReceiveWithAnyArgs().Execute(null);
+            }
+        }
+
+        public class when_querying_discovered_scripts : SpecificationFor<UpgradeEngine>
+        {
+            IJournal versionTracker;
+            IScriptProvider scriptProvider;
+            IScriptExecutor scriptExecutor;
+            List<string> discoveredScripts;
+
+            public override UpgradeEngine Given()
+            {
+                scriptProvider = Substitute.For<IScriptProvider>();
+                versionTracker = Substitute.For<IJournal>();
+                versionTracker.GetExecutedScripts().Returns(new[] { "#1", "#2", "#3" });
+                scriptExecutor = Substitute.For<IScriptExecutor>();
+
+                var config = new UpgradeConfiguration
+                {
+                    ConnectionManager = new TestConnectionManager(Substitute.For<IDbConnection>())
+                };
+                config.ScriptProviders.Add(scriptProvider);
+                config.ScriptExecutor = scriptExecutor;
+                config.Journal = versionTracker;
+
+                var upgrader = new UpgradeEngine(config);
+                return upgrader;
+            }
+
+            protected override void When()
+            {
+                discoveredScripts = Subject.GetExecutedScripts();
+            }
+
+            [Then]
+            public void discovered_scripts_are_returned()
+            {
+                discoveredScripts.ShouldBe(new[] { "#1", "#2", "#3" });
+            }
+        }
+
+        public class when_querying_executed_but_not_discovered_scripts : SpecificationFor<UpgradeEngine>
+        {
+            IJournal versionTracker;
+            IScriptProvider scriptProvider;
+            IScriptExecutor scriptExecutor;
+            List<string> discoveredScripts;
+
+            public override UpgradeEngine Given()
+            {
+                scriptProvider = Substitute.For<IScriptProvider>();
+                scriptProvider.GetScripts(Arg.Any<IConnectionManager>()).Returns(new List<SqlScript>
+                {
+                    new SqlScript("#1", "Content of #1"),
+                    new SqlScript("#3", "Content of #3"),
+                });
+                versionTracker = Substitute.For<IJournal>();
+                versionTracker.GetExecutedScripts().Returns(new[] { "#1", "#2", "#3" });
+                scriptExecutor = Substitute.For<IScriptExecutor>();
+
+                var config = new UpgradeConfiguration
+                {
+                    ConnectionManager = new TestConnectionManager(Substitute.For<IDbConnection>())
+                };
+                config.ScriptProviders.Add(scriptProvider);
+                config.ScriptExecutor = scriptExecutor;
+                config.Journal = versionTracker;
+
+                var upgrader = new UpgradeEngine(config);
+                return upgrader;
+            }
+
+            protected override void When()
+            {
+                discoveredScripts = Subject.GetExecutedButNotDiscoveredScripts();
+            }
+
+            [Then]
+            public void discovered_scripts_are_returned()
+            {
+                discoveredScripts.ShouldBe(new[] { "#2" });
             }
         }
     }


### PR DESCRIPTION
Add methods GetExecutedButNotDiscoveredScripts() and GetDiscoveredScripts() to be able to detect scripts that for some reason are removed from the script provider.

Resolves #425