### PR TITLE
Use Microsoft-Produced SQL Parser for SQL Server

### DIFF
--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -11,6 +11,8 @@ namespace DbUp.SqlServer
     /// </summary>
     public class SqlConnectionManager : DatabaseConnectionManager
     {
+        internal SqlCommandSplitter CommandSplitter { get; set; } = new SqlCommandSplitter();
+
         /// <summary>
         /// Manages Sql Database Connections
         /// </summary>
@@ -29,10 +31,6 @@ namespace DbUp.SqlServer
         }
 
         public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
-        {
-            var commandSplitter = new SqlCommandSplitter();
-            var scriptStatements = commandSplitter.SplitScriptIntoCommands(scriptContents);
-            return scriptStatements;
-        }
+            => CommandSplitter.SplitScriptIntoCommands(scriptContents);
     }
 }

--- a/src/dbup-sqlserver/SqlConnectionManagerExtensions.cs
+++ b/src/dbup-sqlserver/SqlConnectionManagerExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using DbUp.Builder;
+using DbUp.SqlServer;
+
+public static class SqlConnectionManagerExtensions
+{
+    public static UpgradeEngineBuilder WithNewSqlParser(this UpgradeEngineBuilder builder)
+    {
+        builder.Configure(c =>
+        {
+            var connMgr = (c.ConnectionManager as SqlConnectionManager)
+                            ?? throw new NotSupportedException("New SQL Parser is only supported when using the SqlConnectionManager class");
+
+            connMgr.CommandSplitter = new TSqlCommandSplitter();
+        });
+
+        return builder;
+    }
+}

--- a/src/dbup-sqlserver/TSqlCommandSplitter.cs
+++ b/src/dbup-sqlserver/TSqlCommandSplitter.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using DbUp.Support;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace DbUp.SqlServer
+{
+    public class TSqlCommandSplitter : SqlCommandSplitter
+    {
+        readonly TSql150Parser parser;
+
+        public TSqlCommandSplitter()
+        {
+            parser = new TSql150Parser(true, SqlEngineType.All);
+        }
+
+        public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
+        {
+            using (var scriptReader = new StringReader(scriptContents))
+            {
+                var parsedFragment = parser.Parse(scriptReader, out var errors);
+
+                if (errors.Count > 0)
+                {
+                    throw new TSqlParseException($"Failure parsing SQL script \"{errors[0].Message}\" at [{errors[0].Line}, {errors[0].Column}]");
+                }
+
+                var batchBuilder = new StringBuilder();
+
+                foreach (var token in parsedFragment.ScriptTokenStream)
+                {
+                    if (token.TokenType == TSqlTokenType.Go)
+                    {
+                        yield return batchBuilder.ToString().Trim();
+                        batchBuilder = new StringBuilder();
+                        continue;
+                    }
+
+                    batchBuilder.Append(token.Text);
+                }
+
+                yield return batchBuilder.ToString().Trim();
+            }
+        }
+    }
+}

--- a/src/dbup-sqlserver/TSqlParseException.cs
+++ b/src/dbup-sqlserver/TSqlParseException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace DbUp.SqlServer
+{
+    [Serializable]
+    class TSqlParseException : Exception
+    {
+        public TSqlParseException()
+        { }
+
+        public TSqlParseException(string message)
+            : base(message)
+        { }
+
+        public TSqlParseException(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+
+        protected TSqlParseException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        { }
+    }
+}

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -4,7 +4,7 @@
     <Description>DbUp makes it easy to deploy and upgrade SQL Server databases by running change scripts.</Description>
     <Title>DbUp MS Sql Server Support</Title>
     <Authors>Paul Stovell;Jim Burger;Jake Ginnivan;Damian Maclennan</Authors>
-    <TargetFrameworks>netstandard1.3;net35</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>dbup-sqlserver</AssemblyName>
     <AssemblyOriginatorKeyFile>../dbup.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -24,15 +24,15 @@
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <DefineConstants>$(DefineConstants);SUPPORTS_SQL_CONTEXT</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Data" />
     <Reference Include="System" />
   </ItemGroup>

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -21,11 +21,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4576.1-preview" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/dbup-tests/ApiTests.cs
+++ b/src/dbup-tests/ApiTests.cs
@@ -125,7 +125,7 @@ namespace DbUp.Tests
 
         void AppendTypes(StringBuilder sb, int indent, IEnumerable<Type> types)
         {
-            foreach (var type in types)
+            foreach (var type in types.OrderBy(t => t.Name))
             {
                 AppendAttributes(sb, indent, type.GetCustomAttributesData(), false);
 
@@ -222,7 +222,12 @@ namespace DbUp.Tests
             foreach (var property in type.GetProperties(bindingFlags).OrderBy(p => p.Name))
                 AppendProperty(sb, type, indent, property);
 
-            var methods = type.GetMethods(bindingFlags).Where(m => m.IsPublic || m.IsFamily).Where(m => !m.IsSpecialName).OrderBy(p => p.Name);
+            var methods = type.GetMethods(bindingFlags)
+                              .Where(m => m.IsPublic || m.IsFamily)
+                              .Where(m => !m.IsSpecialName)
+                              .OrderBy(p => p.Name)
+                              .ThenByDescending(p => p.GetParameters().Length);
+
             foreach (var method in methods)
                 AppendMethod(sb, indent, method);
 

--- a/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
@@ -17,47 +17,47 @@ public static class StandardExtensions
     public static DbUp.Builder.UpgradeEngineBuilder WithFilter(this DbUp.Builder.UpgradeEngineBuilder builder, DbUp.Engine.IScriptFilter filter) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithoutTransaction(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithPreprocessor(this DbUp.Builder.UpgradeEngineBuilder builder, DbUp.Engine.IScriptPreprocessor preprocessor) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScript(this DbUp.Builder.UpgradeEngineBuilder builder, DbUp.Engine.SqlScript script) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScript(this DbUp.Builder.UpgradeEngineBuilder builder, string name, string contents) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScript(this DbUp.Builder.UpgradeEngineBuilder builder, string name, string contents, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScript(this DbUp.Builder.UpgradeEngineBuilder builder, string name, DbUp.Engine.IScript script) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScript(this DbUp.Builder.UpgradeEngineBuilder builder, string name, DbUp.Engine.IScript script, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScript(this DbUp.Builder.UpgradeEngineBuilder builder, string name, string contents) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScript(this DbUp.Builder.UpgradeEngineBuilder builder, string name, DbUp.Engine.IScript script) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScript(this DbUp.Builder.UpgradeEngineBuilder builder, DbUp.Engine.SqlScript script) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptNameComparer(this DbUp.Builder.UpgradeEngineBuilder builder, System.Collections.Generic.IComparer<string> comparer) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScripts(this DbUp.Builder.UpgradeEngineBuilder builder, System.Func<DbUp.Engine.IScript, string> namer, DbUp.Engine.SqlScriptOptions sqlScriptOptions, params DbUp.Engine.IScript[] scripts) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScripts(this DbUp.Builder.UpgradeEngineBuilder builder, System.Func<DbUp.Engine.IScript, string> namer, params DbUp.Engine.IScript[] scripts) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScripts(this DbUp.Builder.UpgradeEngineBuilder builder, DbUp.Engine.IScriptProvider scriptProvider) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScripts(this DbUp.Builder.UpgradeEngineBuilder builder, System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> scripts) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScripts(this DbUp.Builder.UpgradeEngineBuilder builder, params DbUp.Engine.SqlScript[] scripts) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScripts(this DbUp.Builder.UpgradeEngineBuilder builder, params DbUp.Engine.IScript[] scripts) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScripts(this DbUp.Builder.UpgradeEngineBuilder builder, System.Func<DbUp.Engine.IScript, string> namer, params DbUp.Engine.IScript[] scripts) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScripts(this DbUp.Builder.UpgradeEngineBuilder builder, System.Func<DbUp.Engine.IScript, string> namer, DbUp.Engine.SqlScriptOptions sqlScriptOptions, params DbUp.Engine.IScript[] scripts) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Func<string, bool> filter, System.Func<string, bool> codeScriptFilter, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Func<string, bool> filter, System.Func<string, bool> codeScriptFilter) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Func<string, bool> filter, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Func<string, bool> filter) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Func<string, bool> filter, System.Func<string, bool> codeScriptFilter) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Func<string, bool> filter, System.Func<string, bool> codeScriptFilter, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Func<string, bool> filter, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly[] assemblies) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly[] assemblies, System.Func<string, bool> filter) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly[] assemblies, System.Func<string, bool> filter, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly[] assemblies, System.Text.Encoding encoding) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly[] assemblies, System.Func<string, bool> filter, System.Text.Encoding encoding) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsAndCodeEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly[] assemblies, System.Func<string, bool> filter, System.Text.Encoding encoding, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Text.Encoding encoding) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly[] assemblies, System.Func<string, bool> filter, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly[] assemblies, System.Func<string, bool> filter, System.Text.Encoding encoding) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly[] assemblies, System.Func<string, bool> filter) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly[] assemblies, System.Text.Encoding encoding) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly[] assemblies) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Func<string, bool> filter, System.Text.Encoding encoding, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Text.Encoding encoding, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Func<string, bool> filter, System.Text.Encoding encoding) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Func<string, bool> filter, System.Text.Encoding encoding, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Func<string, bool> filter) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Func<string, bool> filter, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Func<string, bool> filter) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Text.Encoding encoding) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly, System.Func<string, bool> filter) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this DbUp.Builder.UpgradeEngineBuilder builder, System.Reflection.Assembly assembly) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Func<string, bool> filter, System.Text.Encoding encoding, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Func<string, bool> filter, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Text.Encoding encoding) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Text.Encoding encoding, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Func<string, bool> filter, System.Text.Encoding encoding) { }
-    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Func<string, bool> filter, System.Text.Encoding encoding, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Func<string, bool> filter) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Text.Encoding encoding) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, DbUp.ScriptProviders.FileSystemScriptOptions options) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithTransaction(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithTransactionPerScript(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithVariable(this DbUp.Builder.UpgradeEngineBuilder builder, string variableName, string value) { }
@@ -156,8 +156,8 @@ namespace DbUp.Engine
     public interface IScriptExecutor
     {
         System.Nullable<int> ExecutionTimeoutSeconds { get; set; }
-        void Execute(DbUp.Engine.SqlScript script);
         void Execute(DbUp.Engine.SqlScript script, System.Collections.Generic.IDictionary<string, string> variables);
+        void Execute(DbUp.Engine.SqlScript script);
         void VerifySchema();
     }
     public interface IScriptFilter
@@ -174,8 +174,8 @@ namespace DbUp.Engine
     }
     public interface ISqlObjectParser
     {
-        string QuoteIdentifier(string objectName);
         string QuoteIdentifier(string objectName, DbUp.Support.ObjectNameOptions objectNameOptions);
+        string QuoteIdentifier(string objectName);
         string UnquoteIdentifier(string objectName);
     }
     public class LazySqlScript : DbUp.Engine.SqlScript
@@ -197,13 +197,13 @@ namespace DbUp.Engine
         public virtual string Contents { get; }
         public string Name { get; }
         public DbUp.Engine.SqlScriptOptions SqlScriptOptions { get; }
-        public static DbUp.Engine.SqlScript FromFile(string path) { }
-        public static DbUp.Engine.SqlScript FromFile(string path, System.Text.Encoding encoding) { }
-        public static DbUp.Engine.SqlScript FromFile(string basePath, string path, System.Text.Encoding encoding) { }
         public static DbUp.Engine.SqlScript FromFile(string basePath, string path, System.Text.Encoding encoding, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
-        public static DbUp.Engine.SqlScript FromStream(string scriptName, System.IO.Stream stream) { }
-        public static DbUp.Engine.SqlScript FromStream(string scriptName, System.IO.Stream stream, System.Text.Encoding encoding) { }
+        public static DbUp.Engine.SqlScript FromFile(string basePath, string path, System.Text.Encoding encoding) { }
+        public static DbUp.Engine.SqlScript FromFile(string path, System.Text.Encoding encoding) { }
+        public static DbUp.Engine.SqlScript FromFile(string path) { }
         public static DbUp.Engine.SqlScript FromStream(string scriptName, System.IO.Stream stream, System.Text.Encoding encoding, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
+        public static DbUp.Engine.SqlScript FromStream(string scriptName, System.IO.Stream stream, System.Text.Encoding encoding) { }
+        public static DbUp.Engine.SqlScript FromStream(string scriptName, System.IO.Stream stream) { }
     }
     public class SqlScriptOptions
     {
@@ -218,8 +218,8 @@ namespace DbUp.Engine
         public System.Collections.Generic.List<string> GetExecutedScripts() { }
         public System.Collections.Generic.List<DbUp.Engine.SqlScript> GetScriptsToExecute() { }
         public bool IsUpgradeRequired() { }
-        public DbUp.Engine.DatabaseUpgradeResult MarkAsExecuted() { }
         public DbUp.Engine.DatabaseUpgradeResult MarkAsExecuted(string latestScript) { }
+        public DbUp.Engine.DatabaseUpgradeResult MarkAsExecuted() { }
         protected virtual void OnScriptExecuted(DbUp.Engine.ScriptExecutedEventArgs e) { }
         public DbUp.Engine.DatabaseUpgradeResult PerformUpgrade() { }
         public bool TryConnect(out string errorMessage) { }
@@ -368,8 +368,8 @@ namespace DbUp.Helpers
     }
     public static class UpgradeEngineHtmlReport
     {
-        public static void GenerateUpgradeHtmlReport(this DbUp.Engine.UpgradeEngine upgradeEngine, string fullPath) { }
         public static void GenerateUpgradeHtmlReport(this DbUp.Engine.UpgradeEngine upgradeEngine, string fullPath, string serverName, string databaseName) { }
+        public static void GenerateUpgradeHtmlReport(this DbUp.Engine.UpgradeEngine upgradeEngine, string fullPath) { }
     }
 }
 namespace DbUp.ScriptProviders
@@ -428,8 +428,8 @@ namespace DbUp.Support
         public System.Nullable<int> ExecutionTimeoutSeconds { get; set; }
         protected System.Func<DbUp.Engine.Output.IUpgradeLog> Log { get; }
         public string Schema { get; set; }
-        public virtual void Execute(DbUp.Engine.SqlScript script) { }
         public virtual void Execute(DbUp.Engine.SqlScript script, System.Collections.Generic.IDictionary<string, string> variables) { }
+        public virtual void Execute(DbUp.Engine.SqlScript script) { }
         protected virtual void ExecuteAndLogOutput(System.Data.IDbCommand command) { }
         protected abstract void ExecuteCommandsWithinExceptionHandler(int index, DbUp.Engine.SqlScript script, System.Action executeCallback);
         protected virtual void ExecuteNonQuery(System.Data.IDbCommand command) { }
@@ -464,8 +464,8 @@ namespace DbUp.Support
     public abstract class SqlObjectParser : DbUp.Engine.ISqlObjectParser
     {
         protected SqlObjectParser(string quotePrefix, string quoteSuffix) { }
-        public string QuoteIdentifier(string objectName) { }
         public virtual string QuoteIdentifier(string objectName, DbUp.Support.ObjectNameOptions objectNameOptions) { }
+        public string QuoteIdentifier(string objectName) { }
         public virtual string UnquoteIdentifier(string objectName) { }
     }
     public abstract class SqlParser : System.IO.StringReader, System.IDisposable
@@ -490,8 +490,8 @@ namespace DbUp.Support
         protected void OnReadCharacter(DbUp.Support.SqlParser.CharacterType type, char c) { }
         protected void Parse() { }
         protected char PeekChar() { }
-        public override int Read() { }
         public override int Read(char[] buffer, int index, int count) { }
+        public override int Read() { }
         public override int ReadBlock(char[] buffer, int index, int count) { }
         protected virtual void ReadCustomStatement() { }
         public override string ReadLine() { }

--- a/src/dbup-tests/ApprovalFiles/dbup-mysql.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-mysql.approved.cs
@@ -4,11 +4,11 @@
 
 public static class MySqlExtensions
 {
-    public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
+    public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
-    public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
     public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema) { }
+    public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
 }
 namespace DbUp.MySql
 {

--- a/src/dbup-tests/ApprovalFiles/dbup-oracle.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-oracle.approved.cs
@@ -19,11 +19,11 @@ namespace DbUp.Oracle
     }
     public static class OracleExtensions
     {
-        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
+        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
-        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema) { }
+        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
     }
     public class OracleObjectParser : DbUp.Support.SqlObjectParser, DbUp.Engine.ISqlObjectParser
     {

--- a/src/dbup-tests/ApprovalFiles/dbup-postgresql.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-postgresql.approved.cs
@@ -5,13 +5,13 @@
 public static class PostgresqlExtensions
 {
     public static DbUp.Builder.UpgradeEngineBuilder JournalToPostgresqlTable(this DbUp.Builder.UpgradeEngineBuilder builder, string schema, string table) { }
-    public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
+    public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.Engine.Output.IUpgradeLog logger) { }
+    public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
-    public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema) { }
     public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
-    public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.Engine.Output.IUpgradeLog logger) { }
+    public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
 }
 namespace DbUp.Postgresql
 {

--- a/src/dbup-tests/ApprovalFiles/dbup-redshift.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-redshift.approved.cs
@@ -5,13 +5,13 @@
 public static class RedshiftExtensions
 {
     public static DbUp.Builder.UpgradeEngineBuilder JournalToRedshiftTable(this DbUp.Builder.UpgradeEngineBuilder builder, string schema, string table) { }
-    public static DbUp.Builder.UpgradeEngineBuilder RedshiftDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder RedshiftDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
+    public static void RedshiftDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.Engine.Output.IUpgradeLog logger) { }
+    public static DbUp.Builder.UpgradeEngineBuilder RedshiftDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder RedshiftDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
-    public static DbUp.Builder.UpgradeEngineBuilder RedshiftDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
     public static DbUp.Builder.UpgradeEngineBuilder RedshiftDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema) { }
     public static void RedshiftDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
-    public static void RedshiftDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.Engine.Output.IUpgradeLog logger) { }
+    public static DbUp.Builder.UpgradeEngineBuilder RedshiftDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
 }
 namespace DbUp.Redshift
 {

--- a/src/dbup-tests/Support/SqlServer/TSqlCommandSplitterTests.cs
+++ b/src/dbup-tests/Support/SqlServer/TSqlCommandSplitterTests.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using DbUp.SqlServer;
+using DbUp.Support;
+using Shouldly;
+using Xunit;
+
+namespace DbUp.Tests.Support.SqlServer
+{
+    public class TSqlCommandSplitterTests
+    {
+        readonly SqlCommandSplitter sut;
+
+        public TSqlCommandSplitterTests()
+        {
+            sut = new TSqlCommandSplitter();
+        }
+
+        [Fact]
+        public void does_not_split_go_in_column_name()
+        {
+            var statement = @"CREATE PROCEDURE dbo.GetDetails
+
+    @AccountId uniqueidentifier
+
+AS
+BEGIN
+
+SELECT AccountId,
+        EstimatedInCents,
+        OccupationInCents,
+        GovernmentInCents
+FROM Nowhere
+END".Replace("\r\n", "\n");
+
+            var commands = sut.SplitScriptIntoCommands(statement).ToArray();
+
+            commands.Count().ShouldBe(1);
+            commands[0].ShouldBe(statement);
+        }
+
+        [Fact]
+        public void should_treat_bracketed_text_as_single_item()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("SELECT 1 as [']");
+            sb.AppendLine("GO");
+            sb.AppendLine("Select 2");
+            var commands = sut.SplitScriptIntoCommands(sb.ToString());
+            commands.Count().ShouldBe(2);
+        }
+
+        [Fact]
+        public void multiple_brackets_should_escape_properly()
+        {
+            var sql = "Select 1 as [[a]][b]][c]]]";
+            var commands = sut.SplitScriptIntoCommands(sql);
+            commands.Count().ShouldBe(1);
+        }
+
+        [Fact]
+        public void should_split_statements_on_go_and_handle_comments()
+        {
+            var sqlGo = "GO";
+            var sqlGoWithTerminator = "GO;";
+            var sqlBuilder = new StringBuilder();
+
+            // Sql command with a multiline comment containing a GO.
+            sqlBuilder.AppendLine(@"/*"); // Start of sql comment block.
+            sqlBuilder.AppendLine(@"multi line comment 1.");
+            sqlBuilder.AppendLine(@"GO");
+            sqlBuilder.AppendLine(@"--");
+            sqlBuilder.AppendLine(@"Other comment text");
+            sqlBuilder.AppendLine(@"Go");
+            sqlBuilder.AppendLine(@"*/");  // End of sql comment block.
+            sqlBuilder.AppendLine(@"INSERT INTO A (GO) VALUES (1);");
+
+            var sqlCommandWithMultiLineComment = sqlBuilder.ToString();
+            sqlBuilder.Clear();
+
+            // Sql command with a single line comment (no end dashes) containing a GO.
+            sqlBuilder.AppendLine("--Single line Comment no end comment dashes GO");
+            sqlBuilder.AppendLine("INSERT INTO A (X) VALUES ('GO');");
+            var sqlCommandWithSingleLineComment = sqlBuilder.ToString();
+            sqlBuilder.Clear();
+
+            // Sql command with a single line comment (with end dashes) containing a GO.
+            sqlBuilder.AppendLine("--Single line Comment WITH END comment dashes GO --");
+            sqlBuilder.AppendLine("INSERT INTO A (go) VALUES ('Go');");
+
+            var sqlCommandWithSingleLineCommentWithEndDashes = sqlBuilder.ToString();
+            sqlBuilder.Clear();
+
+            // Sql command with a single line comment (with end dashes) containing a GO.
+            sqlBuilder.AppendLine("INSERT INTO [Foo] ([Text])");
+            sqlBuilder.AppendLine("VALUES (N'Some text. /*Strangely Emphasised Text*/ More text')");
+
+            var strangeInsert = sqlBuilder.ToString();
+            sqlBuilder.Clear();
+
+            // Combine into one SQL statement separated with GO.
+            sqlBuilder.AppendLine(sqlCommandWithMultiLineComment);
+            sqlBuilder.AppendLine(sqlGo);
+            sqlBuilder.AppendLine(sqlCommandWithSingleLineComment);
+            sqlBuilder.AppendLine(sqlGoWithTerminator);
+            sqlBuilder.AppendLine(sqlCommandWithSingleLineCommentWithEndDashes);
+            sqlBuilder.AppendLine(sqlGo);
+            sqlBuilder.AppendLine(strangeInsert);
+
+            var sqlText = sqlBuilder.ToString();
+            Console.WriteLine("===== Splitting the following SQL =============");
+            Console.WriteLine(sqlText);
+            Console.WriteLine("===============================================");
+
+            var commands = sut.SplitScriptIntoCommands(sqlText).ToArray();
+
+            var sqlCommands = commands;
+            foreach (var item in sqlCommands)
+            {
+                Console.WriteLine("=========== Parsed Command ============");
+                Console.WriteLine(item);
+                Console.WriteLine("=======================================");
+            }
+            sqlCommands.ShouldNotBeNull();
+            sqlCommands.Length.ShouldBe(4);
+
+            sqlCommands[0].ShouldBe(sqlCommandWithMultiLineComment.Trim());
+            sqlCommands[1].ShouldBe(sqlCommandWithSingleLineComment.Trim());
+            sqlCommands[2].ShouldBe($";{Environment.NewLine}{sqlCommandWithSingleLineCommentWithEndDashes.Trim()}");
+            sqlCommands[3].ShouldBe(strangeInsert.Trim());
+        }
+    }
+}


### PR DESCRIPTION
(TO DO - write this summary properly)

- Uses the `Microsoft.SqlServer.DacFx` package to parse script contents to split to commands
- Updates the SQL Server package frameworks through necessity (required by the `DacFx` package)
- Duplicates unit tests because existing `SqlCommandSplitter` tests aren't valid SQL