### PR TITLE
Allow getting UpgradeConfiguration from UpgradeEngineBuilder

### DIFF
--- a/src/dbup-core/Builder/UpgradeEngineBuilder.cs
+++ b/src/dbup-core/Builder/UpgradeEngineBuilder.cs
@@ -22,10 +22,10 @@ namespace DbUp.Builder
         }
 
         /// <summary>
-        /// Creates an UpgradeEngine based on this configuration.
+        /// Creates an UpgradeConfiguration based on this configuration.
         /// </summary>
         /// <returns></returns>
-        public UpgradeEngine Build()
+        public UpgradeConfiguration BuildConfiguration()
         {
             var config = new UpgradeConfiguration();
             foreach (var callback in callbacks)
@@ -35,6 +35,16 @@ namespace DbUp.Builder
 
             config.Validate();
 
+            return config;
+        }
+
+        /// <summary>
+        /// Creates an UpgradeEngine based on this configuration.
+        /// </summary>
+        /// <returns></returns>
+        public UpgradeEngine Build()
+        {
+            var config = BuildConfiguration();
             return new UpgradeEngine(config);
         }
     }

--- a/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
@@ -131,6 +131,7 @@ namespace DbUp.Builder
     {
         public UpgradeEngineBuilder() { }
         public DbUp.Engine.UpgradeEngine Build() { }
+        public DbUp.Builder.UpgradeConfiguration BuildConfiguration() { }
         public void Configure(System.Action<DbUp.Builder.UpgradeConfiguration> configuration) { }
     }
 }


### PR DESCRIPTION
Add a new method called BuildConfiguration that gets
theUpgradeConfiguration that would have been used to create
theUpgradeEngine.

Closes DbUp/DbUp#426