### PR TITLE
Allow use of Azure AppAuthentication integrated security

### DIFF
--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using DbUp.Engine.Transactions;
 using DbUp.Support;
+#if SUPPORTS_AZURE_AD
+using Microsoft.Azure.Services.AppAuthentication;
+#endif
 
 namespace DbUp.SqlServer
 {
@@ -15,10 +18,18 @@ namespace DbUp.SqlServer
         /// Manages Sql Database Connections
         /// </summary>
         /// <param name="connectionString"></param>
-        public SqlConnectionManager(string connectionString)
+        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity)
             : base(new DelegateConnectionFactory((log, dbManager) =>
             {
                 var conn = new SqlConnection(connectionString);
+
+#if SUPPORTS_AZURE_AD
+                if(useAzureSqlIntegratedSecurity)
+                    conn.AccessToken = (new AzureServiceTokenProvider()).GetAccessTokenAsync("https://database.windows.net/").GetAwaiter().GetResult();
+#else
+                if(useAzureSqlIntegratedSecurity)
+                    throw new Exception("You are targeting a framework that does not support Azure AppAuthentication. The minimum target frameworks are .NET Framework 4.5.2 and .NET Standard 1.4.");
+#endif
 
                 if (dbManager.IsScriptOutputLogged)
                     conn.InfoMessage += (sender, e) => log.WriteInformation($"{{0}}{Environment.NewLine}", e.Message);

--- a/src/dbup-sqlserver/SqlServerExtensions.cs
+++ b/src/dbup-sqlserver/SqlServerExtensions.cs
@@ -24,9 +24,9 @@ public static class SqlServerExtensions
     /// <returns>
     /// A builder for a database upgrader designed for SQL Server databases.
     /// </returns>
-    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, string connectionString)
+    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, string connectionString, bool useAzureSqlIntegratedSecurity = false)
     {
-        return SqlDatabase(supported, connectionString, null);
+        return SqlDatabase(supported, connectionString, null, useAzureSqlIntegratedSecurity);
     }
 
     /// <summary>
@@ -38,9 +38,9 @@ public static class SqlServerExtensions
     /// <returns>
     /// A builder for a database upgrader designed for SQL Server databases.
     /// </returns>
-    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, string connectionString, string schema)
+    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity = false)
     {
-        return SqlDatabase(new SqlConnectionManager(connectionString), schema);
+        return SqlDatabase(new SqlConnectionManager(connectionString, useAzureSqlIntegratedSecurity), schema);
     }
 
     /// <summary>

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -4,7 +4,7 @@
     <Description>DbUp makes it easy to deploy and upgrade SQL Server databases by running change scripts.</Description>
     <Title>DbUp MS Sql Server Support</Title>
     <Authors>Paul Stovell;Jim Burger;Jake Ginnivan;Damian Maclennan</Authors>
-    <TargetFrameworks>netstandard1.3;net35</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net35;net46</TargetFrameworks>
     <AssemblyName>dbup-sqlserver</AssemblyName>
     <AssemblyOriginatorKeyFile>../dbup.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -24,17 +24,38 @@
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="System.Data" />
+    <Reference Include="System" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication">
+      <Version>1.3.1</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
+    <Reference Include="System.Data" />
+    <Reference Include="System" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' ">
     <DefineConstants>$(DefineConstants);SUPPORTS_SQL_CONTEXT</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <Reference Include="System.Data" />
-    <Reference Include="System" />
-  </ItemGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_SQL_CONTEXT;SUPPORTS_AZURE_AD</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_AZURE_AD</DefineConstants>
+  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Adds an optional flag to SqlServer to UseAzureIntegratedSecurity. This allows us to use the new AppAuthentication package which connects to Azure resources using integrated security from within a Visual Studio instance or from a Managed Identity for a service on Azure.