### PR TITLE
Make useAzureSqlIntegratedSecurity optional & fix target framework msg

### DIFF
--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -18,7 +18,7 @@ namespace DbUp.SqlServer
         /// Manages Sql Database Connections
         /// </summary>
         /// <param name="connectionString"></param>
-        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity)
+        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity = false)
             : base(new DelegateConnectionFactory((log, dbManager) =>
             {
                 var conn = new SqlConnection(connectionString);
@@ -28,7 +28,7 @@ namespace DbUp.SqlServer
                     conn.AccessToken = (new AzureServiceTokenProvider()).GetAccessTokenAsync("https://database.windows.net/").GetAwaiter().GetResult();
 #else
                 if(useAzureSqlIntegratedSecurity)
-                    throw new Exception("You are targeting a framework that does not support Azure AppAuthentication. The minimum target frameworks are .NET Framework 4.5.2 and .NET Standard 1.4.");
+                    throw new Exception("You are targeting a framework that does not support Azure AppAuthentication. The minimum target frameworks are .NET Framework 4.6 and .NET Standard 2.0.");
 #endif
 
                 if (dbManager.IsScriptOutputLogged)

--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -18,7 +18,16 @@ namespace DbUp.SqlServer
         /// Manages Sql Database Connections
         /// </summary>
         /// <param name="connectionString"></param>
-        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity = false)
+        public SqlConnectionManager(string connectionString)
+            : this(connectionString, false)
+        {
+        }
+
+        /// <summary>
+        /// Manages Sql Database Connections
+        /// </summary>
+        /// <param name="connectionString"></param>
+        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity)
             : base(new DelegateConnectionFactory((log, dbManager) =>
             {
                 var conn = new SqlConnection(connectionString);

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -24,17 +24,13 @@
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' Or '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Data" />
     <Reference Include="System" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication">
-      <Version>1.3.1</Version>
-    </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <Reference Include="System.Data" />
-    <Reference Include="System" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">


### PR DESCRIPTION
A couple fixes to yesterday's merged PR #465.

1) Make SqlConnectionManager:useAzureIntegratedSecurity parameter optional. Before this fix, it was a breaking change to anyone using SqlConnectionManager directly.
2) Correct the minimum supported frameworks in the unsupported-framework exception message.