### PR TITLE
Enable using SSL with Postgres

### DIFF
--- a/src/dbup-postgresql/PostgresqlConnectionManager.cs
+++ b/src/dbup-postgresql/PostgresqlConnectionManager.cs
@@ -25,13 +25,13 @@ namespace DbUp.Postgresql
         /// Creates a new PostgreSQL database connection with a certificate.
         /// </summary>
         /// <param name="connectionString">The PostgreSQL connection string.</param>
-        /// <param name="certificateFile">A byte array representation of an X509 certificate.</param>
-        public PostgresqlConnectionManager(string connectionString, byte[] certificateFile)
+        /// <param name="certificate">Certificate for securing connection.</param>
+        public PostgresqlConnectionManager(string connectionString, X509Certificate2 certificate)
             : base(new DelegateConnectionFactory(l =>
                 {
                     NpgsqlConnection databaseConnection = new NpgsqlConnection(connectionString);
                     databaseConnection.ProvideClientCertificatesCallback +=
-                        certs => certs.Add(new X509Certificate2(certificateFile));
+                        certs => certs.Add(certificate);
 
                     return databaseConnection;
                 }

--- a/src/dbup-postgresql/PostgresqlConnectionManager.cs
+++ b/src/dbup-postgresql/PostgresqlConnectionManager.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions; 
 using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions; 
 using DbUp.Engine.Transactions;
 using Npgsql;
 

--- a/src/dbup-postgresql/PostgresqlConnectionManager.cs
+++ b/src/dbup-postgresql/PostgresqlConnectionManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
+using System.Text.RegularExpressions; 
+using System.Security.Cryptography.X509Certificates;
 using DbUp.Engine.Transactions;
 using Npgsql;
 
@@ -17,6 +18,24 @@ namespace DbUp.Postgresql
         /// <param name="connectionString">The PostgreSQL connection string.</param>
         public PostgresqlConnectionManager(string connectionString)
             : base(new DelegateConnectionFactory(l => new NpgsqlConnection(connectionString)))
+        {
+        }
+
+        /// <summary>
+        /// Creates a new PostgreSQL database connection with a certificate.
+        /// </summary>
+        /// <param name="connectionString">The PostgreSQL connection string.</param>
+        /// <param name="certificateFile">A byte array representation of an X509 certificate.</param>
+        public PostgresqlConnectionManager(string connectionString, byte[] certificateFile)
+            : base(new DelegateConnectionFactory(l =>
+                {
+                    NpgsqlConnection databaseConnection = new NpgsqlConnection(connectionString);
+                    databaseConnection.ProvideClientCertificatesCallback +=
+                        certs => certs.Add(new X509Certificate2(certificateFile));
+
+                    return databaseConnection;
+                }
+                ))
         {
         }
 

--- a/src/dbup-postgresql/PostgresqlExtensions.cs
+++ b/src/dbup-postgresql/PostgresqlExtensions.cs
@@ -44,12 +44,12 @@ public static class PostgresqlExtensions
     /// <param name="supported">Fluent helper type.</param>
     /// <param name="connectionString">PostgreSQL database connection string.</param>
     /// <param name="schema">The schema in which to check for changes</param>
-    /// <param name="certificateFile">A byte array representation of an X509 certificate.</param>
+    /// <param name="certificate">Certificate for securing connection.</param>
     /// <returns>
     /// A builder for a database upgrader designed for PostgreSQL databases.
     /// </returns>
-    public static UpgradeEngineBuilder PostgresqlDatabase(this SupportedDatabases supported, string connectionString, string schema, byte[] certificateFile)
-        => PostgresqlDatabase(new PostgresqlConnectionManager(connectionString, certificateFile), schema);
+    public static UpgradeEngineBuilder PostgresqlDatabase(this SupportedDatabases supported, string connectionString, string schema, X509Certificate2 certificate)
+        => PostgresqlDatabase(new PostgresqlConnectionManager(connectionString, certificate), schema);
 
     /// <summary>
     /// Creates an upgrader for PostgreSQL databases.
@@ -106,11 +106,11 @@ public static class PostgresqlExtensions
     /// </summary>
     /// <param name="supported">Fluent helper type.</param>
     /// <param name="connectionString">The connection string.</param>
-    /// <param name="certificateFile">A byte array representation of an X509 certificate.</param>
+    /// <param name="certificate">Certificate for securing connection.</param>
     /// <returns></returns>
-    public static void PostgresqlDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString, byte[] certificateFile)
+    public static void PostgresqlDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString, X509Certificate2 certificate)
     {
-        PostgresqlDatabase(supported, connectionString, new ConsoleUpgradeLog(), certificateFile);
+        PostgresqlDatabase(supported, connectionString, new ConsoleUpgradeLog(), certificate);
     }
 
     /// <summary>
@@ -125,7 +125,7 @@ public static class PostgresqlExtensions
         PostgresqlDatabase(supported, connectionString, logger, null);
     }
 
-    private static void PostgresqlDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString, IUpgradeLog logger, byte[] certificateFile)
+    private static void PostgresqlDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString, IUpgradeLog logger, X509Certificate2 certificate)
     {
         if (supported == null) throw new ArgumentNullException("supported");
 
@@ -157,10 +157,10 @@ public static class PostgresqlExtensions
 
         using (var connection = new NpgsqlConnection(masterConnectionStringBuilder.ConnectionString))
         {
-            if (certificateFile != null)
+            if (certificate!= null)
             {
                 connection.ProvideClientCertificatesCallback +=
-                    certs => certs.Add(new X509Certificate2(certificateFile));
+                    certs => certs.Add(certificate);
             }
             connection.Open();
 

--- a/src/dbup-postgresql/PostgresqlExtensions.cs
+++ b/src/dbup-postgresql/PostgresqlExtensions.cs
@@ -11,7 +11,7 @@ using Npgsql;
 // ReSharper disable once CheckNamespace
 
 /// <summary>
-/// Configuration  extension methods for PostgreSQL.
+/// Configuration extension methods for PostgreSQL.
 /// </summary>
 public static class PostgresqlExtensions
 {

--- a/src/dbup-postgresql/PostgresqlExtensions.cs
+++ b/src/dbup-postgresql/PostgresqlExtensions.cs
@@ -157,7 +157,7 @@ public static class PostgresqlExtensions
 
         using (var connection = new NpgsqlConnection(masterConnectionStringBuilder.ConnectionString))
         {
-            if (certificate!= null)
+            if (certificate != null)
             {
                 connection.ProvideClientCertificatesCallback +=
                     certs => certs.Add(certificate);

--- a/src/dbup-postgresql/PostgresqlExtensions.cs
+++ b/src/dbup-postgresql/PostgresqlExtensions.cs
@@ -11,7 +11,7 @@ using Npgsql;
 // ReSharper disable once CheckNamespace
 
 /// <summary>
-/// Configuration extension methods for PostgreSQL.
+/// Configuration  extension methods for PostgreSQL.
 /// </summary>
 public static class PostgresqlExtensions
 {

--- a/src/dbup-tests/ApprovalFiles/dbup-postgresql.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-postgresql.approved.cs
@@ -7,12 +7,12 @@ public static class PostgresqlExtensions
     public static DbUp.Builder.UpgradeEngineBuilder JournalToPostgresqlTable(this DbUp.Builder.UpgradeEngineBuilder builder, string schema, string table) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
-    public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, System.Byte[] certificateFile) { }
+    public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema) { }
     public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
-    public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, System.Byte[] certificateFile) { }
+    public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
     public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.Engine.Output.IUpgradeLog logger) { }
 }
 namespace DbUp.Postgresql
@@ -20,7 +20,7 @@ namespace DbUp.Postgresql
     public class PostgresqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
         public PostgresqlConnectionManager(string connectionString) { }
-        public PostgresqlConnectionManager(string connectionString, System.Byte[] certificateFile) { }
+        public PostgresqlConnectionManager(string connectionString, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class PostgresqlObjectParser : DbUp.Support.SqlObjectParser, DbUp.Engine.ISqlObjectParser

--- a/src/dbup-tests/ApprovalFiles/dbup-postgresql.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-postgresql.approved.cs
@@ -7,10 +7,12 @@ public static class PostgresqlExtensions
     public static DbUp.Builder.UpgradeEngineBuilder JournalToPostgresqlTable(this DbUp.Builder.UpgradeEngineBuilder builder, string schema, string table) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
+    public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, System.Byte[] certificateFile) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema) { }
     public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
+    public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, System.Byte[] certificateFile) { }
     public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.Engine.Output.IUpgradeLog logger) { }
 }
 namespace DbUp.Postgresql
@@ -18,6 +20,7 @@ namespace DbUp.Postgresql
     public class PostgresqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
         public PostgresqlConnectionManager(string connectionString) { }
+        public PostgresqlConnectionManager(string connectionString, System.Byte[] certificateFile) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class PostgresqlObjectParser : DbUp.Support.SqlObjectParser, DbUp.Engine.ISqlObjectParser


### PR DESCRIPTION
New PostgresqlConnectionManager that takes a byte array
of the .pfx file to be used as the certificate for connecting
to Postgres using SSL.

New PostgresqlExtension method for creating an
UpgradeEngineBuilder with the certificate.

Minor refactor of EnsureDatabase function so that it
can optionally take the certificate.