### PR TITLE
Fixed duplicate key exception when retrying PerformUpgrade

### DIFF
--- a/src/dbup-core/Engine/UpgradeEngine.cs
+++ b/src/dbup-core/Engine/UpgradeEngine.cs
@@ -95,7 +95,14 @@ namespace DbUp.Engine
             }
             catch (Exception ex)
             {
-                ex.Data.Add("Error occurred in script: ", executedScriptName);
+                const string scriptNameKey = "Error occurred in script: ";
+
+                // Exception can be re-used when using connection pooling
+                if (ex.Data.Contains(scriptNameKey))
+                    ex.Data[scriptNameKey] = executedScriptName;
+                else
+                    ex.Data.Add(scriptNameKey, executedScriptName);
+
                 configuration.Log.WriteError("Upgrade failed due to an unexpected exception:\r\n{0}", ex.ToString());
                 return new DatabaseUpgradeResult(executed, false, ex);
             }

--- a/src/dbup-core/Engine/UpgradeEngine.cs
+++ b/src/dbup-core/Engine/UpgradeEngine.cs
@@ -95,14 +95,7 @@ namespace DbUp.Engine
             }
             catch (Exception ex)
             {
-                const string scriptNameKey = "Error occurred in script: ";
-
-                // Exception can be re-used when using connection pooling
-                if (ex.Data.Contains(scriptNameKey))
-                    ex.Data[scriptNameKey] = executedScriptName;
-                else
-                    ex.Data.Add(scriptNameKey, executedScriptName);
-
+                ex.Data["Error occurred in script: "] = executedScriptName;
                 configuration.Log.WriteError("Upgrade failed due to an unexpected exception:\r\n{0}", ex.ToString());
                 return new DatabaseUpgradeResult(executed, false, ex);
             }


### PR DESCRIPTION
During service startup, if the SQL server is unreachable we retry DbUp after a few seconds until it succeeds. We noticed that after a few attempts we got a key violation exception instead of the connection timeout, which could be traced back to the PerformUpgrade exception handler which adds the script name to the Exception data.

If we use "pooling=false" in the connection string this issue does not occur. It looks like the Exception is sometimes re-used by the SqlConnection. This fix works around it by checking the Data dictionary, so we at least get the original exception back.