### PR TITLE
Added a new transaction strategy that does rollback at the end of transaction

### DIFF
--- a/src/dbup-core/Builder/StandardExtensions.cs
+++ b/src/dbup-core/Builder/StandardExtensions.cs
@@ -757,6 +757,18 @@ public static class StandardExtensions
     }
 
     /// <summary>
+    /// Run DbUp in a single transaction but rollback at the end
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    public static UpgradeEngineBuilder WithTransactionButRollback(this UpgradeEngineBuilder builder)
+    {
+        builder.Configure(c => c.ConnectionManager.TransactionMode = TransactionMode.SingleTransactionWithRollback);
+
+        return builder;
+    }
+
+    /// <summary>
     /// Run each script in it's own transaction
     /// </summary>
     /// <param name="builder"></param>

--- a/src/dbup-core/Builder/StandardExtensions.cs
+++ b/src/dbup-core/Builder/StandardExtensions.cs
@@ -761,9 +761,9 @@ public static class StandardExtensions
     /// </summary>
     /// <param name="builder"></param>
     /// <returns></returns>
-    public static UpgradeEngineBuilder WithTransactionButRollback(this UpgradeEngineBuilder builder)
+    public static UpgradeEngineBuilder WithTransactionAlwaysRollback(this UpgradeEngineBuilder builder)
     {
-        builder.Configure(c => c.ConnectionManager.TransactionMode = TransactionMode.SingleTransactionWithRollback);
+        builder.Configure(c => c.ConnectionManager.TransactionMode = TransactionMode.SingleTransactionAlwaysRollback);
 
         return builder;
     }

--- a/src/dbup-core/Engine/Transactions/DatabaseConnectionManager.cs
+++ b/src/dbup-core/Engine/Transactions/DatabaseConnectionManager.cs
@@ -35,7 +35,7 @@ namespace DbUp.Engine.Transactions
                 {TransactionMode.NoTransaction, ()=>new NoTransactionStrategy()},
                 {TransactionMode.SingleTransaction, ()=>new SingleTransactionStrategy()},
                 {TransactionMode.TransactionPerScript, ()=>new TransactionPerScriptStrategy()},
-                {TransactionMode.SingleTransactionWithRollback, ()=>new SingleTransactionWithRollbackStrategy()}
+                {TransactionMode.SingleTransactionAlwaysRollback, ()=>new SingleTransactionAlwaysRollbackStrategy()}
             };
         }
 

--- a/src/dbup-core/Engine/Transactions/DatabaseConnectionManager.cs
+++ b/src/dbup-core/Engine/Transactions/DatabaseConnectionManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using DbUp.Engine.Output;
@@ -34,7 +34,8 @@ namespace DbUp.Engine.Transactions
             {
                 {TransactionMode.NoTransaction, ()=>new NoTransactionStrategy()},
                 {TransactionMode.SingleTransaction, ()=>new SingleTransactionStrategy()},
-                {TransactionMode.TransactionPerScript, ()=>new TransactionPerScriptStrategy()}
+                {TransactionMode.TransactionPerScript, ()=>new TransactionPerScriptStrategy()},
+                {TransactionMode.SingleTransactionWithRollback, ()=>new SingleTransactionWithRollbackStrategy()}
             };
         }
 

--- a/src/dbup-core/Engine/Transactions/SingleTransactionAlwaysRollbackStrategy.cs
+++ b/src/dbup-core/Engine/Transactions/SingleTransactionAlwaysRollbackStrategy.cs
@@ -77,11 +77,14 @@ namespace DbUp.Engine.Transactions
                 log.WriteWarning("Error occured when executing scripts, transaction will be rolled back");
             }
 
+            // Always rollback
+            transaction?.Rollback();
+
             //Restore the executed scripts collection
             executedScriptsCollection.Clear();
             executedScriptsCollection.AddRange(executedScriptsListBeforeExecution);
 
-            transaction.Dispose();
+            transaction?.Dispose();
         }
     }
 }

--- a/src/dbup-core/Engine/Transactions/SingleTransactionAlwaysRollbackStrategy.cs
+++ b/src/dbup-core/Engine/Transactions/SingleTransactionAlwaysRollbackStrategy.cs
@@ -5,7 +5,7 @@ using DbUp.Engine.Output;
 
 namespace DbUp.Engine.Transactions
 {
-    class SingleTransactionWithRollbackStrategy : ITransactionStrategy
+    class SingleTransactionAlwaysRollbackStrategy : ITransactionStrategy
     {
         IDbConnection connection;
         IDbTransaction transaction;

--- a/src/dbup-core/Engine/Transactions/SingleTransactionWithRollbackStrategy.cs
+++ b/src/dbup-core/Engine/Transactions/SingleTransactionWithRollbackStrategy.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using DbUp.Engine.Output;
+
+namespace DbUp.Engine.Transactions
+{
+    class SingleTransactionWithRollbackStrategy : ITransactionStrategy
+    {
+        IDbConnection connection;
+        IDbTransaction transaction;
+        bool errorOccured;
+        IUpgradeLog log;
+        SqlScript[] executedScriptsListBeforeExecution;
+        List<SqlScript> executedScriptsCollection;
+
+        public void Execute(Action<Func<IDbCommand>> action)
+        {
+            if (errorOccured)
+                throw new InvalidOperationException("Error occured on previous script execution");
+
+            try
+            {
+                action(() =>
+                {
+                    var command = connection.CreateCommand();
+                    command.Transaction = transaction;
+                    return command;
+                });
+            }
+            catch (Exception)
+            {
+                errorOccured = true;
+                throw;
+            }
+        }
+
+        public T Execute<T>(Func<Func<IDbCommand>, T> actionWithResult)
+        {
+            if (errorOccured)
+                throw new InvalidOperationException("Error occured on previous script execution");
+
+            try
+            {
+                return actionWithResult(() =>
+                {
+                    var command = connection.CreateCommand();
+                    command.Transaction = transaction;
+                    return command;
+                });
+            }
+            catch (Exception)
+            {
+                errorOccured = true;
+                throw;
+            }
+        }
+
+        public void Initialise(IDbConnection dbConnection, IUpgradeLog upgradeLog, List<SqlScript> executedScripts)
+        {
+            executedScriptsCollection = executedScripts;
+            executedScriptsListBeforeExecution = executedScripts.ToArray();
+            connection = dbConnection;
+            log = upgradeLog;
+            upgradeLog.WriteInformation("Beginning transaction");
+            transaction = connection.BeginTransaction();
+        }
+
+        public void Dispose()
+        {
+            if (!errorOccured)
+            {
+                log.WriteInformation("Success! No errors have occured when executing scripts, transaction will be rolled back");
+            }
+            else
+            {
+                log.WriteWarning("Error occured when executing scripts, transaction will be rolled back");
+            }
+
+            //Restore the executed scripts collection
+            executedScriptsCollection.Clear();
+            executedScriptsCollection.AddRange(executedScriptsListBeforeExecution);
+
+            transaction.Dispose();
+        }
+    }
+}

--- a/src/dbup-core/Engine/Transactions/TransactionMode.cs
+++ b/src/dbup-core/Engine/Transactions/TransactionMode.cs
@@ -1,4 +1,4 @@
-namespace DbUp.Engine.Transactions
+﻿namespace DbUp.Engine.Transactions
 {
     /// <summary>
     /// The transaction strategy to use
@@ -18,6 +18,11 @@ namespace DbUp.Engine.Transactions
         /// <summary>
         /// DbUp will run scripts using a separate transaction per script
         /// </summary>
-        TransactionPerScript
+        TransactionPerScript,
+
+        /// <summary>
+        /// DbUp will run scripts using a single transaction for the whole upgrade operation but will rollback at the end
+        /// </summary>
+        SingleTransactionWithRollback
     }
 }

--- a/src/dbup-core/Engine/Transactions/TransactionMode.cs
+++ b/src/dbup-core/Engine/Transactions/TransactionMode.cs
@@ -23,6 +23,6 @@
         /// <summary>
         /// DbUp will run scripts using a single transaction for the whole upgrade operation but will rollback at the end
         /// </summary>
-        SingleTransactionWithRollback
+        SingleTransactionAlwaysRollback
     }
 }

--- a/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
@@ -59,6 +59,7 @@ public static class StandardExtensions
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, System.Func<string, bool> filter, System.Text.Encoding encoding, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithScriptsFromFileSystem(this DbUp.Builder.UpgradeEngineBuilder builder, string path, DbUp.ScriptProviders.FileSystemScriptOptions options) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithTransaction(this DbUp.Builder.UpgradeEngineBuilder builder) { }
+    public static DbUp.Builder.UpgradeEngineBuilder WithTransactionAlwaysRollback(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithTransactionPerScript(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithVariable(this DbUp.Builder.UpgradeEngineBuilder builder, string variableName, string value) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithVariables(this DbUp.Builder.UpgradeEngineBuilder builder, System.Collections.Generic.IDictionary<string, string> variables) { }
@@ -348,6 +349,7 @@ namespace DbUp.Engine.Transactions
         NoTransaction = 0
         SingleTransaction = 1
         TransactionPerScript = 2
+        SingleTransactionAlwaysRollback = 3
     }
 }
 namespace DbUp.Helpers


### PR DESCRIPTION
Wery usefull when
-  you want to test if the scripts won't fail
-  to integrate in a CI pipeline. Fail the build if any of the scripts fail to execute

It is like running in the command line 'dotnet new console --dry-run' where you see what files are going to be created by they wont be created