### PR TITLE
Write failed script to DatabaseUpgradeResult

### DIFF
--- a/src/dbup-core/Engine/DatabaseUpgradeResult.cs
+++ b/src/dbup-core/Engine/DatabaseUpgradeResult.cs
@@ -11,6 +11,7 @@ namespace DbUp.Engine
         readonly List<SqlScript> scripts;
         readonly bool successful;
         readonly Exception error;
+        readonly SqlScript errorScript;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DatabaseUpgradeResult"/> class.
@@ -18,12 +19,13 @@ namespace DbUp.Engine
         /// <param name="scripts">The scripts that were executed.</param>
         /// <param name="successful">if set to <c>true</c> [successful].</param>
         /// <param name="error">The error.</param>
-        public DatabaseUpgradeResult(IEnumerable<SqlScript> scripts, bool successful, Exception error)
+        public DatabaseUpgradeResult(IEnumerable<SqlScript> scripts, bool successful, Exception error, SqlScript errorScript)
         {
             this.scripts = new List<SqlScript>();
             this.scripts.AddRange(scripts);
             this.successful = successful;
             this.error = error;
+            this.errorScript = errorScript;
         }
 
         /// <summary>
@@ -40,5 +42,10 @@ namespace DbUp.Engine
         /// Gets the error.
         /// </summary>
         public Exception Error => error;
+
+        /// <summary>
+        /// Gets the script that was executing when an error occured.
+        /// </summary>
+        public SqlScript ErrorScript => errorScript;
     }
 }

--- a/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
@@ -139,8 +139,9 @@ namespace DbUp.Engine
 {
     public sealed class DatabaseUpgradeResult
     {
-        public DatabaseUpgradeResult(System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> scripts, bool successful, System.Exception error) { }
+        public DatabaseUpgradeResult(System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> scripts, bool successful, System.Exception error, DbUp.Engine.SqlScript errorScript) { }
         public System.Exception Error { get; }
+        public DbUp.Engine.SqlScript ErrorScript { get; }
         public System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> Scripts { get; }
         public bool Successful { get; }
     }

--- a/src/dbup-tests/UpgradeDatabaseScenarios.cs
+++ b/src/dbup-tests/UpgradeDatabaseScenarios.cs
@@ -94,6 +94,7 @@ namespace DbUp.Tests
                 .Then(t => t.ThenShouldNotRunAnyScripts())
                 .And(t => t.AndShouldHaveFailedResult())
                 .And(t => t.AndErrorMessageShouldBeLogged())
+                .And(t => t.AndScriptThatErroredIsRecorded())
                 .BDDfy();
         }
 
@@ -107,6 +108,7 @@ namespace DbUp.Tests
                 .Then(t => t.ThenShouldNotRunAnyScripts())
                 .And(t => t.AndShouldHaveFailedResult())
                 .And(t => t.AndErrorMessageShouldBeLogged())
+                .And(t => t.AndScriptThatErroredIsRecorded())
                 .BDDfy();
         }
 
@@ -136,6 +138,11 @@ namespace DbUp.Tests
         {
             scripts.Clear();
             AndTheFourthScriptToRunHasAnError();
+        }
+
+        void AndScriptThatErroredIsRecorded()
+        {
+            upgradeResult.ErrorScript.Name.ShouldContain("ScriptWithError.sql");
         }
 
         void AndShouldLogInformation()


### PR DESCRIPTION
Took a shot at #325 by adding an ErrorScript property to DatabaseUpgradeResult. 

Fails the public API change test, but judging by the suggested fix on the issue, I think that is to be expected. Not sure what your process is for updating those tests if this change is accepted, but happy to do it with instruction.