### PR TITLE
Oracle adapter does not correctly handle custom statement

### DIFF
--- a/src/dbup-oracle/OracleCommandReader.cs
+++ b/src/dbup-oracle/OracleCommandReader.cs
@@ -18,8 +18,8 @@ namespace DbUp.Oracle
         /// <summary>
         /// Hook to support custom statements
         /// </summary>
-        protected override bool IsCustomStatement => TryPeek(DelimiterKeyword.Length, out var statement) &&
-                       string.Equals(DelimiterKeyword, statement, StringComparison.OrdinalIgnoreCase);
+        protected override bool IsCustomStatement => TryPeek(DelimiterKeyword.Length - 1, out var statement) &&
+                       string.Equals(DelimiterKeyword, CurrentChar + statement, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Read a custom statement

--- a/src/dbup-tests/Support/Oracle/OracleConnectionManagerTests.cs
+++ b/src/dbup-tests/Support/Oracle/OracleConnectionManagerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Text;
 using DbUp.Oracle;
 using Shouldly;
 using Xunit;
@@ -31,5 +32,26 @@ namespace DbUp.Tests.Support.Oracle
 
             result.Count().ShouldBe(2);
         }
+
+        [Fact]
+        public void ParsesOutBeginningDelimiter()
+        {
+            const string singleCommand = "select banner as \"oracle version\" from v$version";
+            var multiCommand = new StringBuilder()
+                .AppendLine("DELIMITER $$")
+                .AppendLine(singleCommand + "$$")
+                .Append(singleCommand);
+
+            var connectionManager = new OracleConnectionManager("connectionstring");
+            var result = connectionManager.SplitScriptIntoCommands(multiCommand.ToString())
+                .ToArray();
+
+            result.ShouldBe(new[]
+            {
+                singleCommand,
+                singleCommand
+            });
+        }
+
     }
 }

--- a/src/dbup-tests/Support/Oracle/OracleConnectionManagerTests.cs
+++ b/src/dbup-tests/Support/Oracle/OracleConnectionManagerTests.cs
@@ -37,6 +37,8 @@ namespace DbUp.Tests.Support.Oracle
         public void ParsesOutBeginningDelimiter()
         {
             const string singleCommand = "select banner as \"oracle version\" from v$version";
+            
+            // commands separated only with customer delimiter - no semicolon
             var multiCommand = new StringBuilder()
                 .AppendLine("DELIMITER $$")
                 .AppendLine(singleCommand + "$$")


### PR DESCRIPTION
This PR fixes an issue with the Oracle adapter when using custom statement separator via the `DELIMITER` keyword.
The issue was that this keyword was ignored if it was right at the beginning of a script.
Added unit test as well to avoid a regression in the future.