### PR TITLE
Changed the Oracle implementation to split on `/` instead of `;`.

### DIFF
--- a/src/dbup-oracle/OracleCommandSplitter.cs
+++ b/src/dbup-oracle/OracleCommandSplitter.cs
@@ -1,9 +1,24 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using DbUp.Support;
 
 namespace DbUp.Oracle
 {
     public class OracleCommandSplitter
     {
+        private readonly Func<string, SqlCommandReader> commandReaderFactory;
+
+        [Obsolete]
+        public OracleCommandSplitter()
+        {
+            this.commandReaderFactory = scriptContents => new OracleCommandReader(scriptContents);
+        }
+        
+        public OracleCommandSplitter(char delimiter)
+        {
+            this.commandReaderFactory = scriptContents => new OracleCustomDelimiterCommandReader(scriptContents, delimiter);
+        }
+        
         /// <summary>
         /// Splits a script with multiple delimited commands into commands
         /// </summary>
@@ -11,7 +26,7 @@ namespace DbUp.Oracle
         /// <returns></returns>
         public IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
         {
-            using (var reader = new OracleCommandReader(scriptContents))
+            using (var reader = commandReaderFactory(scriptContents))
             {
                 var commands = new List<string>();
                 reader.ReadAllCommands(c => commands.Add(c));

--- a/src/dbup-oracle/OracleConnectionManager.cs
+++ b/src/dbup-oracle/OracleConnectionManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using DbUp.Engine.Transactions;
 using Oracle.ManagedDataAccess.Client;
 
@@ -6,17 +7,27 @@ namespace DbUp.Oracle
 {
     public class OracleConnectionManager : DatabaseConnectionManager
     {
+        private readonly OracleCommandSplitter commandSplitter;
+
         /// <summary>
         /// Creates a new Oracle database connection.
         /// </summary>
         /// <param name="connectionString">The Oracle connection string.</param>
-        public OracleConnectionManager(string connectionString) : base(new DelegateConnectionFactory(l => new OracleConnection(connectionString)))
+        [Obsolete]
+        public OracleConnectionManager(string connectionString)
+            : this(connectionString, new OracleCommandSplitter())
         {
+            Console.WriteLine();
+        }
+        
+        public OracleConnectionManager(string connectionString, OracleCommandSplitter commandSplitter)
+            : base(new DelegateConnectionFactory(l => new OracleConnection(connectionString)))
+        {
+            this.commandSplitter = commandSplitter;
         }
 
         public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
         {
-            var commandSplitter = new OracleCommandSplitter();
             var scriptStatements = commandSplitter.SplitScriptIntoCommands(scriptContents);
             return scriptStatements;
         }

--- a/src/dbup-oracle/OracleCustomDelimiterCommandReader.cs
+++ b/src/dbup-oracle/OracleCustomDelimiterCommandReader.cs
@@ -1,26 +1,26 @@
-﻿using System;
+using System;
 using System.Text;
 using DbUp.Support;
 
 namespace DbUp.Oracle
 {
-    [Obsolete]
-    public class OracleCommandReader : SqlCommandReader
+    public class OracleCustomDelimiterCommandReader : SqlCommandReader
     {
         const string DelimiterKeyword = "DELIMITER";
 
         /// <summary>
         /// Creates an instance of OracleCommandReader
         /// </summary>
-        public OracleCommandReader(string sqlText) : base(sqlText, ";", delimiterRequiresWhitespace: false)
+        public OracleCustomDelimiterCommandReader(string sqlText, char delimiter) : base(sqlText, delimiter.ToString(), delimiterRequiresWhitespace: false)
         {
         }
 
         /// <summary>
         /// Hook to support custom statements
         /// </summary>
-        protected override bool IsCustomStatement => TryPeek(DelimiterKeyword.Length, out var statement) &&
-                                                     string.Equals(DelimiterKeyword, statement, StringComparison.OrdinalIgnoreCase);
+        protected override bool IsCustomStatement
+            => TryPeek(DelimiterKeyword.Length - 1, out var statement) &&
+               string.Equals(DelimiterKeyword, CurrentChar + statement, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Read a custom statement

--- a/src/dbup-oracle/OracleExtensions.cs
+++ b/src/dbup-oracle/OracleExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using DbUp.Builder;
 using DbUp.Engine.Transactions;
 
@@ -6,6 +7,7 @@ namespace DbUp.Oracle
 {
     public static class OracleExtensions
     {
+        [Obsolete("Use OracleDatabaseWithSlashDelimiter, OracleDatabaseWithSemicolonDelimiter or the OracleDatabase with the delimiter parameter instead, see https://github.com/DbUp/DbUp/pull/335")]
         public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, string connectionString)
         {
             foreach (var pair in connectionString.Split(';').Select(s => s.Split('=')).Where(pair => pair.Length == 2).Where(pair => pair[0].ToLower() == "database"))
@@ -17,6 +19,34 @@ namespace DbUp.Oracle
         }
 
         /// <summary>
+        /// Use / as the delimiter between statements
+        /// </summary>
+        /// <param name="supported"></param>
+        /// <param name="connectionString"></param>
+        /// <returns></returns>
+        public static UpgradeEngineBuilder OracleDatabaseWithDefaultDelimiter(this SupportedDatabases supported, string connectionString)
+            => OracleDatabase(supported, connectionString, '/');
+        
+        /// <summary>
+        /// Use ; as the delimiter between statements
+        /// </summary>
+        /// <param name="supported"></param>
+        /// <param name="connectionString"></param>
+        /// <returns></returns>
+        public static UpgradeEngineBuilder OracleDatabaseWithSemicolonDelimiter(this SupportedDatabases supported, string connectionString)
+            => OracleDatabase(supported, connectionString, ';');
+
+        public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, string connectionString, char delimiter)
+        {
+            foreach (var pair in connectionString.Split(';').Select(s => s.Split('=')).Where(pair => pair.Length == 2).Where(pair => pair[0].ToLower() == "database"))
+            {
+                return OracleDatabase(new OracleConnectionManager(connectionString, new OracleCommandSplitter(delimiter)), pair[1]);
+            }
+
+            return OracleDatabase(new OracleConnectionManager(connectionString, new OracleCommandSplitter(delimiter)));
+        }
+
+        /// <summary>
         /// Creates an upgrader for Oracle databases.
         /// </summary>
         /// <param name="supported">Fluent helper type.</param>
@@ -25,11 +55,26 @@ namespace DbUp.Oracle
         /// <returns>
         /// A builder for a database upgrader designed for Oracle databases.
         /// </returns>
+        [Obsolete("Use the parameter that takes a delimiter instead, see https://github.com/DbUp/DbUp/pull/335")]
         public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, string connectionString, string schema)
         {
             return OracleDatabase(new OracleConnectionManager(connectionString), schema);
         }
 
+        /// <summary>
+        /// Creates an upgrader for Oracle databases.
+        /// </summary>
+        /// <param name="supported">Fluent helper type.</param>
+        /// <param name="connectionString">Oracle database connection string.</param>
+        /// <param name="schema">Which Oracle schema to check for changes</param>
+        /// <returns>
+        /// A builder for a database upgrader designed for Oracle databases.
+        /// </returns>
+        public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, string connectionString, string schema, string delimiter)
+        {
+            return OracleDatabase(new OracleConnectionManager(connectionString), schema);
+        }
+        
         /// <summary>
         /// Creates an upgrader for Oracle databases.
         /// </summary>

--- a/src/dbup-tests/ApprovalFiles/dbup-oracle.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-oracle.approved.cs
@@ -1,6 +1,7 @@
 
 namespace DbUp.Oracle
 {
+    [System.ObsoleteAttribute()]
     public class OracleCommandReader : DbUp.Support.SqlCommandReader, System.IDisposable
     {
         public OracleCommandReader(string sqlText) { }
@@ -9,21 +10,37 @@ namespace DbUp.Oracle
     }
     public class OracleCommandSplitter
     {
+        [System.ObsoleteAttribute()]
         public OracleCommandSplitter() { }
+        public OracleCommandSplitter(char delimiter) { }
         public System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class OracleConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
+        [System.ObsoleteAttribute()]
         public OracleConnectionManager(string connectionString) { }
+        public OracleConnectionManager(string connectionString, DbUp.Oracle.OracleCommandSplitter commandSplitter) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
+    }
+    public class OracleCustomDelimiterCommandReader : DbUp.Support.SqlCommandReader, System.IDisposable
+    {
+        public OracleCustomDelimiterCommandReader(string sqlText, char delimiter) { }
+        protected override bool IsCustomStatement { get; }
+        protected override void ReadCustomStatement() { }
     }
     public static class OracleExtensions
     {
+        [System.ObsoleteAttribute("Use OracleDatabaseWithSlashDelimiter, OracleDatabaseWithSemicolonDelimiter or the OracleDatabase with the delimiter parameter instead, see https://github.com/DbUp/DbUp/pull/335")]
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
+        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, char delimiter) { }
+        [System.ObsoleteAttribute("Use the parameter that takes a delimiter instead, see https://github.com/DbUp/DbUp/pull/335")]
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
+        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string delimiter) { }
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema) { }
+        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabaseWithDefaultDelimiter(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
+        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabaseWithSemicolonDelimiter(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     }
     public class OracleObjectParser : DbUp.Support.SqlObjectParser, DbUp.Engine.ISqlObjectParser
     {

--- a/src/dbup-tests/DatabaseSupportTests.cs
+++ b/src/dbup-tests/DatabaseSupportTests.cs
@@ -91,7 +91,7 @@ namespace DbUp.Tests
                         builder.Configure(c => c.Journal = new SQLiteTableJournal(() => c.ConnectionManager, () => c.Log, tableName));
                         return builder;
                     })),
-                    new ExampleAction("Oracle", Deploy(to => to.OracleDatabase(string.Empty), (builder, schema, tableName) => { builder.Configure(c => c.Journal = new OracleTableJournal(()=>c.ConnectionManager, ()=>c.Log, schema, tableName)); return builder; })),
+                    new ExampleAction("Oracle", Deploy(to => to.OracleDatabaseWithDefaultDelimiter(string.Empty), (builder, schema, tableName) => { builder.Configure(c => c.Journal = new OracleTableJournal(()=>c.ConnectionManager, ()=>c.Log, schema, tableName)); return builder; })),
 
 #if !NETCORE
                     new ExampleAction("Firebird", Deploy(to => to.FirebirdDatabase(string.Empty), (builder, schema, tableName) => { builder.Configure(c => c.Journal = new FirebirdTableJournal(()=>c.ConnectionManager, ()=>c.Log, tableName)); return builder; })),

--- a/src/dbup-tests/Support/Oracle/OracleConnectionManagerTests.cs
+++ b/src/dbup-tests/Support/Oracle/OracleConnectionManagerTests.cs
@@ -11,9 +11,9 @@ namespace DbUp.Tests.Support.Oracle
         [Fact]
         public void CanParseSingleLineScript()
         {
-            const string singleCommand = "create table FOO (myid INT NOT NULL);";
+            const string singleCommand = "create table FOO (myid INT NOT NULL)/";
 
-            var connectionManager = new OracleConnectionManager("connectionstring");
+            var connectionManager = new OracleConnectionManager("connectionstring", new OracleCommandSplitter('/'));
             var result = connectionManager.SplitScriptIntoCommands(singleCommand);
 
             result.Count().ShouldBe(1);
@@ -22,11 +22,11 @@ namespace DbUp.Tests.Support.Oracle
         [Fact]
         public void CanParseMultilineScript()
         {
-            var multiCommand = "create table FOO (myid INT NOT NULL);";
+            var multiCommand = "create table FOO (myid INT NOT NULL)/";
             multiCommand += Environment.NewLine;
-            multiCommand += "create table BAR (myid INT NOT NULL);";
+            multiCommand += "create table BAR (myid INT NOT NULL)";
 
-            var connectionManager = new OracleConnectionManager("connectionstring");
+            var connectionManager = new OracleConnectionManager("connectionstring", new OracleCommandSplitter('/'));
             var result = connectionManager.SplitScriptIntoCommands(multiCommand);
 
             result.Count().ShouldBe(2);


### PR DESCRIPTION
Based on  #335

I don't want to bump a major version just for this change, so I added overloads for the new behaviour and deprecated the old path. We'll remove it completely in the next major. Use `OracleDatabaseWithDefaultDelimiter` for the new behaviour and `OracleDatabaseWithSemicolonDelimiter` for the old instead of `OracleDatabase`