### PR TITLE
Fixed NRE on PerformUpgrade error handling

### DIFF
--- a/src/dbup-core/Engine/UpgradeEngine.cs
+++ b/src/dbup-core/Engine/UpgradeEngine.cs
@@ -95,7 +95,10 @@ namespace DbUp.Engine
             }
             catch (Exception ex)
             {
-                ex.Data["Error occurred in script: "] = executedScript.Name;
+                if (executedScript != null)
+                {
+                    ex.Data["Error occurred in script: "] = executedScript.Name;
+                }
                 configuration.Log.WriteError("Upgrade failed due to an unexpected exception:\r\n{0}", ex.ToString());
                 return new DatabaseUpgradeResult(executed, false, ex, executedScript);
             }


### PR DESCRIPTION
When connection error has occurred and no scripts executed, there is NullReferenceException on error handling block.