### PR TITLE
Add option not to prefix scripts with subdir names

### DIFF
--- a/src/dbup-core/ScriptProviders/FileSystemScriptOptions.cs
+++ b/src/dbup-core/ScriptProviders/FileSystemScriptOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 
 namespace DbUp.ScriptProviders
@@ -22,9 +22,9 @@ namespace DbUp.ScriptProviders
         public bool IncludeSubDirectories { get; set; }
 
         /// <summary>
-        /// The provider will prefix script names with their subdirectory names.
+        /// The provider will not prefix script names with their subdirectory names.
         /// </summary>
-        public bool PrefixWithSubDirectoryNames { get; set; } = true;
+        public bool UseOnlyFilenameForScriptName { get; set; } = false;
 
         /// <summary>
         /// The filter to be used for filtering files 

--- a/src/dbup-core/ScriptProviders/FileSystemScriptOptions.cs
+++ b/src/dbup-core/ScriptProviders/FileSystemScriptOptions.cs
@@ -22,6 +22,11 @@ namespace DbUp.ScriptProviders
         public bool IncludeSubDirectories { get; set; }
 
         /// <summary>
+        /// The provider will prefix script names with their subdirectory names.
+        /// </summary>
+        public bool PrefixWithSubDirectoryNames { get; set; } = true;
+
+        /// <summary>
         /// The filter to be used for filtering files 
         /// <remarks> Files which does not end by .sql are never considered </remarks>
         /// </summary>

--- a/src/dbup-core/ScriptProviders/FileSystemScriptProvider.cs
+++ b/src/dbup-core/ScriptProviders/FileSystemScriptProvider.cs
@@ -79,12 +79,14 @@ namespace DbUp.ScriptProviders
                         new DirectoryInfo(directoryPath).GetFiles(scriptExtension, ShouldSearchSubDirectories())
                     );
                 }
-                foreach (var fileInfo in files)
-                {
-                    if (files.Count(f => f.Name == fileInfo.Name) > 1)
-                    {
-                        throw new Exception($"Duplicate filename: {fileInfo.Name}");
+                var dupeFiles = files.GroupBy(f => f.Name).Where(grp => grp.Count() > 1).SelectMany(f => f.Select(fi => fi.FullName)).ToList();
+                if (dupeFiles.Count > 0) {
+                    var sbError = new StringBuilder();
+                    sbError.AppendLine("Duplicate filenames:");
+                    foreach (var file in dupeFiles) {
+                        sbError.AppendLine($"- {file}");
                     }
+                    throw new Exception(sbError.ToString());
                 }
                 if (filter != null)
                 {

--- a/src/dbup-core/ScriptProviders/FileSystemScriptProvider.cs
+++ b/src/dbup-core/ScriptProviders/FileSystemScriptProvider.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -55,7 +55,7 @@ namespace DbUp.ScriptProviders
         /// </summary>
         public IEnumerable<SqlScript> GetScripts(IConnectionManager connectionManager)
         {
-            if (options.PrefixWithSubDirectoryNames)
+            if (!options.UseOnlyFilenameForScriptName)
             {
                 var files = new List<string>();
                 foreach (var scriptExtension in options.Extensions)

--- a/src/dbup-core/ScriptProviders/FileSystemScriptProvider.cs
+++ b/src/dbup-core/ScriptProviders/FileSystemScriptProvider.cs
@@ -55,18 +55,45 @@ namespace DbUp.ScriptProviders
         /// </summary>
         public IEnumerable<SqlScript> GetScripts(IConnectionManager connectionManager)
         {
-            var files = new List<string>();
-            foreach (var scriptExtension in options.Extensions)
+            if (options.PrefixWithSubDirectoryNames)
             {
-                files.AddRange(Directory.GetFiles(directoryPath, scriptExtension, ShouldSearchSubDirectories()));
+                var files = new List<string>();
+                foreach (var scriptExtension in options.Extensions)
+                {
+                    files.AddRange(Directory.GetFiles(directoryPath, scriptExtension, ShouldSearchSubDirectories()));
+                }
+                if (filter != null)
+                {
+                    files = files.Where(filter).ToList();
+                }
+                return files.Select(x => SqlScript.FromFile(directoryPath, x, encoding, sqlScriptOptions))
+                    .OrderBy(x => x.Name)
+                    .ToList();
             }
-            if (filter != null)
+            else
             {
-                files = files.Where(filter).ToList();
+                var files = new List<FileInfo>();
+                foreach (var scriptExtension in options.Extensions)
+                {
+                    files.AddRange(
+                        new DirectoryInfo(directoryPath).GetFiles(scriptExtension, ShouldSearchSubDirectories())
+                    );
+                }
+                foreach (var fileInfo in files)
+                {
+                    if (files.Count(f => f.Name == fileInfo.Name) > 1)
+                    {
+                        throw new Exception($"Duplicate filename: {fileInfo.Name}");
+                    }
+                }
+                if (filter != null)
+                {
+                    files = files.Where(x => filter(x.Name)).ToList();
+                }
+                return files.Select(x => SqlScript.FromStream(x.Name, new FileStream(x.FullName, FileMode.Open, FileAccess.Read), encoding, sqlScriptOptions))
+                    .OrderBy(x => x.Name)
+                    .ToList();
             }
-            return files.Select(x => SqlScript.FromFile(directoryPath, x, encoding, sqlScriptOptions))
-                .OrderBy(x => x.Name)
-                .ToList();
         }
 
         SearchOption ShouldSearchSubDirectories()

--- a/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
@@ -409,6 +409,7 @@ namespace DbUp.ScriptProviders
         public string[] Extensions { get; set; }
         public System.Func<string, bool> Filter { get; set; }
         public bool IncludeSubDirectories { get; set; }
+        public bool PrefixWithSubDirectoryNames { get; set; }
     }
     public class FileSystemScriptProvider : DbUp.Engine.IScriptProvider
     {

--- a/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
@@ -409,7 +409,7 @@ namespace DbUp.ScriptProviders
         public string[] Extensions { get; set; }
         public System.Func<string, bool> Filter { get; set; }
         public bool IncludeSubDirectories { get; set; }
-        public bool UseFullPathAsScriptName { get; set; }
+        public bool UseOnlyFilenameForScriptName { get; set; }
     }
     public class FileSystemScriptProvider : DbUp.Engine.IScriptProvider
     {

--- a/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
@@ -409,7 +409,7 @@ namespace DbUp.ScriptProviders
         public string[] Extensions { get; set; }
         public System.Func<string, bool> Filter { get; set; }
         public bool IncludeSubDirectories { get; set; }
-        public bool PrefixWithSubDirectoryNames { get; set; }
+        public bool UseFullPathAsScriptName { get; set; }
     }
     public class FileSystemScriptProvider : DbUp.Engine.IScriptProvider
     {

--- a/src/dbup-tests/ScriptProvider/FileSystemScriptProviderTests.cs
+++ b/src/dbup-tests/ScriptProvider/FileSystemScriptProviderTests.cs
@@ -189,7 +189,7 @@ namespace DbUp.Tests.ScriptProvider
             public override FileSystemScriptProvider Given()
             {
                 TestScripts.Create(out testPath);
-                var options = new FileSystemScriptOptions() { IncludeSubDirectories = true, PrefixWithSubDirectoryNames = false };
+                var options = new FileSystemScriptOptions() { IncludeSubDirectories = true, UseOnlyFilenameForScriptName = true };
                 return new FileSystemScriptProvider(testPath, options);
             }
 

--- a/src/dbup-tests/ScriptProvider/FileSystemScriptProviderTests.cs
+++ b/src/dbup-tests/ScriptProvider/FileSystemScriptProviderTests.cs
@@ -181,6 +181,66 @@ namespace DbUp.Tests.ScriptProvider
             }
         }
 
+        public class when_returning_scripts_from_a_directory_and_using_subdirectories_option_without_prefix : SpecificationFor<FileSystemScriptProvider>, IDisposable
+        {
+            string testPath;
+            IEnumerable<SqlScript> filesToExecute;
+
+            public override FileSystemScriptProvider Given()
+            {
+                TestScripts.Create(out testPath);
+                var options = new FileSystemScriptOptions() { IncludeSubDirectories = true, PrefixWithSubDirectoryNames = false };
+                return new FileSystemScriptProvider(testPath, options);
+            }
+
+            protected override void When()
+            {
+                filesToExecute = Subject.GetScripts(Substitute.For<IConnectionManager>());
+            }
+
+            [Then]
+            public void it_should_return_all_sql_files()
+            {
+                filesToExecute.Count().ShouldBe(9);
+            }
+
+            [Then]
+            public void the_file_should_contain_content()
+            {
+                foreach (var sqlScript in filesToExecute)
+                {
+                    sqlScript.Contents.Length.ShouldBeGreaterThan(0);
+                }
+            }
+
+            [Then]
+            public void the_files_should_not_contain_the_subfolder_name()
+            {
+                filesToExecute
+                        .Select(f => f.Name)
+                        .ShouldContain("dbup-tests.TestScripts.Test1__9.sql");
+            }
+
+            [Then]
+            public void the_files_should_be_correctly_ordered_without_subdirectory_order()
+            {
+                filesToExecute.ElementAt(0).Name.ShouldEndWith("Script20110301_1_Test1.sql");
+                filesToExecute.ElementAt(1).Name.ShouldEndWith("Script20110301_2_Test2.sql");
+                filesToExecute.ElementAt(2).Name.ShouldEndWith("Script20110302_1_Test3.sql");
+                filesToExecute.ElementAt(3).Name.ShouldEndWith("Script20130525_1_Test5.sql");
+                filesToExecute.ElementAt(4).Name.ShouldEndWith("Script20130525_2_Test5.sql");
+                filesToExecute.ElementAt(5).Name.ShouldEndWith("Test1__1.sql");
+                filesToExecute.ElementAt(6).Name.ShouldEndWith("Test1__9.sql");
+                filesToExecute.ElementAt(7).Name.ShouldEndWith("Test2__1.sql");
+                filesToExecute.ElementAt(8).Name.ShouldEndWith("Test2__9.sql");
+            }
+
+            public void Dispose()
+            {
+                Directory.Delete(testPath, true);
+            }
+        }
+
         [Fact]
         public void options_should_include_sql()
         {


### PR DESCRIPTION
I want to organize my scripts into subdirectories but still sort just on filename, so I've added this option not to include subdir name in script names with loading from subdirectories.