### PR TITLE
SqlCommandReader add ability to ignore comments

### DIFF
--- a/src/dbup-core/Support/SqlCommandReader.cs
+++ b/src/dbup-core/Support/SqlCommandReader.cs
@@ -11,14 +11,16 @@ namespace DbUp.Support
     public class SqlCommandReader : SqlParser
     {
         readonly StringBuilder commandScriptBuilder;
+        readonly bool ignoreComments;
 
         /// <summary>
         /// Creates an instance of <see cref="SqlCommandReader"/>.
         /// </summary>
-        public SqlCommandReader(string sqlText, string delimiter = "GO", bool delimiterRequiresWhitespace = true)
+        public SqlCommandReader(string sqlText, string delimiter = "GO", bool delimiterRequiresWhitespace = true, bool ignoreComments = false)
             : base(sqlText, delimiter, delimiterRequiresWhitespace)
         {
             commandScriptBuilder = new StringBuilder();
+            this.ignoreComments = ignoreComments;
         }
 
         /// <summary>
@@ -32,9 +34,14 @@ namespace DbUp.Support
                 {
                     switch (type)
                     {
-                        case CharacterType.Command:
                         case CharacterType.SlashStarComment:
                         case CharacterType.DashComment:
+                            if (!ignoreComments)
+                            {
+                                commandScriptBuilder.Append(c);
+                            }
+                            break;
+                        case CharacterType.Command:
                         case CharacterType.BracketedText:
                         case CharacterType.QuotedString:
                         case CharacterType.CustomStatement:

--- a/src/dbup-oracle/OracleCommandSplitter.cs
+++ b/src/dbup-oracle/OracleCommandSplitter.cs
@@ -14,9 +14,9 @@ namespace DbUp.Oracle
             this.commandReaderFactory = scriptContents => new OracleCommandReader(scriptContents);
         }
         
-        public OracleCommandSplitter(char delimiter)
+        public OracleCommandSplitter(char delimiter, bool ignoreComments = false)
         {
-            this.commandReaderFactory = scriptContents => new OracleCustomDelimiterCommandReader(scriptContents, delimiter);
+            this.commandReaderFactory = scriptContents => new OracleCustomDelimiterCommandReader(scriptContents, delimiter, ignoreComments);
         }
         
         /// <summary>

--- a/src/dbup-oracle/OracleCustomDelimiterCommandReader.cs
+++ b/src/dbup-oracle/OracleCustomDelimiterCommandReader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 using DbUp.Support;
 
@@ -11,7 +11,7 @@ namespace DbUp.Oracle
         /// <summary>
         /// Creates an instance of OracleCommandReader
         /// </summary>
-        public OracleCustomDelimiterCommandReader(string sqlText, char delimiter) : base(sqlText, delimiter.ToString(), delimiterRequiresWhitespace: false)
+        public OracleCustomDelimiterCommandReader(string sqlText, char delimiter, bool ignoreComments = false) : base(sqlText, delimiter.ToString(), delimiterRequiresWhitespace: false, ignoreComments)
         {
         }
 

--- a/src/dbup-tests/Support/Oracle/OracleConnectionManagerTests.cs
+++ b/src/dbup-tests/Support/Oracle/OracleConnectionManagerTests.cs
@@ -31,5 +31,22 @@ namespace DbUp.Tests.Support.Oracle
 
             result.Count().ShouldBe(2);
         }
+
+        [Fact]
+        public void CanParseWithoutCommentTest()
+        {
+            var multiCommand = @"
+-- inline comment that should be ignored
+/*
+   multiline comment that should be ignored
+*/
+create table FOO /*comment*/(text VARCHAR(255) NOT NULL DEFAULT '/*not a comment*/ --not a comment')/ -- inline comment that should be ignored
+";
+            var connectionManager = new OracleConnectionManager("connectionstring", new OracleCommandSplitter('/', ignoreComments:true));
+            var result = connectionManager.SplitScriptIntoCommands(multiCommand);
+
+            result.Count().ShouldBe(1, "there is more than 1 command");
+            result.Single().ShouldBe("create table FOO (text VARCHAR(255) NOT NULL DEFAULT '/*not a comment*/ --not a comment')", "the command not match");
+        }
     }
 }


### PR DESCRIPTION
I found a way to resolve the #479 bug. 
Its a tiny upgrade introducted with an optionnal parameter "ignoreComments" in SqlCommandReader.
The default is setted to false to keep existing process.

I spread the parameter to oracle support but i can go deeper !