### PR TITLE
Pass script options to embeddedScriptProvider

### DIFF
--- a/src/dbup-core/ScriptProviders/EmbeddedScriptAndCodeProvider.cs
+++ b/src/dbup-core/ScriptProviders/EmbeddedScriptAndCodeProvider.cs
@@ -60,7 +60,7 @@ namespace DbUp.ScriptProviders
             this.assembly = assembly;
             this.filter = codeScriptFilter ?? filter;
             this.sqlScriptOptions = sqlScriptOptions;
-            embeddedScriptProvider = new EmbeddedScriptProvider(assembly, filter);
+            embeddedScriptProvider = new EmbeddedScriptProvider(assembly, filter, DbUpDefaults.DefaultEncoding, sqlScriptOptions);
         }
 
         IEnumerable<SqlScript> ScriptsFromScriptClasses(IConnectionManager connectionManager)


### PR DESCRIPTION
The `EmbeddedScriptAndCodeProvider` was creating its internal `embeddedScriptProvider` with the default `SqlScriptOptions` instead of the instance passed by the caller. As a result, custom values for `ScriptType` and `RunGroupOrder` were being applied to code-based scripts, but not embedded script files.