### PR TITLE
Fixed issue #421: Upgraded oracle for .net standard 2.0

### DIFF
--- a/src/dbup-oracle/dbup-oracle.csproj
+++ b/src/dbup-oracle/dbup-oracle.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Oracle.ManagedDataAccess.Core">
-      <Version>2.12.0-beta2</Version>
+      <Version>2.19.100</Version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
Upgraded oracle managed dataaccess client for .net standard 2.0
You may want to look into combining to use the oracle.managedataccess.core library for both .netframework and standard.
