### PR TITLE
Make Script.Name virtual as well so c# scripts can use their type name

### DIFF
--- a/src/dbup-core/Engine/SqlScript.cs
+++ b/src/dbup-core/Engine/SqlScript.cs
@@ -46,7 +46,7 @@ namespace DbUp.Engine
         /// <summary>
         /// Gets the name of the script.
         /// </summary>
-        public string Name { get; }
+        public virtual string Name { get; }
 
         /// <summary>
         /// Create a <see cref="SqlScript"/> from a file using Default encoding

--- a/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-core.approved.cs
@@ -201,7 +201,7 @@ namespace DbUp.Engine
         public SqlScript(string name, string contents) { }
         public SqlScript(string name, string contents, DbUp.Engine.SqlScriptOptions sqlScriptOptions) { }
         public virtual string Contents { get; }
-        public string Name { get; }
+        public virtual string Name { get; }
         public DbUp.Engine.SqlScriptOptions SqlScriptOptions { get; }
         public static DbUp.Engine.SqlScript FromFile(string path) { }
         public static DbUp.Engine.SqlScript FromFile(string path, System.Text.Encoding encoding) { }


### PR DESCRIPTION
For c# based ugprade scripts, we'd like to base the name of the script on the class name. It's currently impossible to do that since you have to pass the name in through the `base(...)` call where you can't get the current type.

A hack/workaround is to set `Name` via reflection 
![image](https://user-images.githubusercontent.com/2888279/99764145-24cd3500-2b48-11eb-89d5-3d8324ca9e36.png)

The proposed way to support this use case to make `Name` virtual, like the `Content` property.
