### PR TITLE
Fix logs to output formatted values

### DIFF
--- a/src/dbup-core/Support/ScriptExecutor.cs
+++ b/src/dbup-core/Support/ScriptExecutor.cs
@@ -231,14 +231,15 @@ namespace DbUp.Support
                 format = "|" + format;
                 totalLength += 1;
 
-                Log().WriteInformation(new string('-', totalLength));
-                Log().WriteInformation(format, names.ToArray());
-                Log().WriteInformation(new string('-', totalLength));
+                var delimiterLine = new string('-', totalLength);
+                Log().WriteInformation(delimiterLine);
+                Log().WriteInformation(string.Format(format, names.ToArray()));
+                Log().WriteInformation(delimiterLine);
                 foreach (var line in lines)
                 {
-                    Log().WriteInformation(format, line.ToArray());
+                    Log().WriteInformation(string.Format(format, line.ToArray()));
                 }
-                Log().WriteInformation(new string('-', totalLength));
+                Log().WriteInformation(delimiterLine);
                 Log().WriteInformation("\r\n");
             } while (reader.NextResult());
         }

--- a/src/dbup-tests/Support/SqlServer/SqlScriptExecutorTests.cs
+++ b/src/dbup-tests/Support/SqlServer/SqlScriptExecutorTests.cs
@@ -230,9 +230,9 @@ namespace DbUp.Tests.Support.SqlServer
                       {
                           "Info:         Executing Database Server script 'Test'",
                           "Info:         -------------",
-                          "Info:         | One | Two | ",
+                          "Info:         | One | Two |",
                           "Info:         -------------",
-                          "Info:         |   A |   B | ",
+                          "Info:         |   A |   B |",
                           "Info:         -------------",
                           "Info:"
                       }));

--- a/src/dbup-tests/Support/SqlServer/SqlScriptExecutorTests.cs
+++ b/src/dbup-tests/Support/SqlServer/SqlScriptExecutorTests.cs
@@ -226,13 +226,16 @@ namespace DbUp.Tests.Support.SqlServer
             command.CommandText.ShouldBe("SELECT * FROM [foo].[Table]");
 
             logger.Log.Trim()
-                      .ShouldBe(@"Info:         Executing Database Server script 'Test'
-Info:         -------------
-Info:         | One | Two |
-Info:         -------------
-Info:         |   A |   B |
-Info:         -------------
-Info:");
+                      .ShouldBe(string.Join(Environment.NewLine, new[]
+                      {
+                          "Info:         Executing Database Server script 'Test'",
+                          "Info:         -------------",
+                          "Info:         | One | Two | ",
+                          "Info:         -------------",
+                          "Info:         |   A |   B | ",
+                          "Info:         -------------",
+                          "Info:"
+                      }));
         }
 
         [Fact]


### PR DESCRIPTION
Console output
```sql
SELECT 1 as age, 'aaa' as name FROM DUAL
/
```


Before:
```
[13:36:15 INF] ---------------
[13:36:15 INF] | {0, 3} | {1, 5} |
[13:36:16 INF] ---------------
[13:36:16 INF] | {0, 3} | {1, 5} |
[13:36:17 INF] ---------------
[13:36:17 INF]
```

After
```
[13:35:14 INF] ---------------
[13:35:14 INF] | AGE |  NAME |
[13:35:15 INF] ---------------
[13:35:15 INF] |   1 |   aaa |
[13:35:15 INF] ---------------
[13:35:16 INF]
```