### PR TITLE
Adding support for .NET 5.0 by replacing `System.Data.SqlClient` with `Microsoft.Data.SqlClient`.

### DIFF
--- a/src/dbup-core/dbup-core.csproj
+++ b/src/dbup-core/dbup-core.csproj
@@ -4,7 +4,7 @@
     <Description>DbUp makes it easy to deploy and upgrade SQL Server databases by running change scripts. This is the core library and should be used in conjunction with the database specific package (eg dbup-sqlserver, dbup-mysql)</Description>
     <Title>DbUp Core library</Title>
     <Authors>Paul Stovell;Jim Burger;Jake Ginnivan;Damian Maclennan</Authors>
-    <TargetFrameworks>netstandard1.3;net35;net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net35;net45;netstandard2.0;net5.0</TargetFrameworks>
     <AssemblyName>dbup-core</AssemblyName>
     <RootNamespace>DbUp</RootNamespace>
     <AssemblyOriginatorKeyFile>../dbup.snk</AssemblyOriginatorKeyFile>

--- a/src/dbup-sqlserver/Helpers/TemporarySqlDatabase.cs
+++ b/src/dbup-sqlserver/Helpers/TemporarySqlDatabase.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+#if USE_MSSQLCLIENT
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using DbUp.Helpers;
 
 namespace DbUp.SqlServer.Helpers

--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+#if USE_MSSQLCLIENT
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using DbUp.Engine.Transactions;
 using DbUp.Support;
 #if SUPPORTS_AZURE_AD

--- a/src/dbup-sqlserver/SqlScriptExecutor.cs
+++ b/src/dbup-sqlserver/SqlScriptExecutor.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+#if USE_MSSQLCLIENT
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using DbUp.Engine;
 using DbUp.Engine.Output;
 using DbUp.Engine.Transactions;

--- a/src/dbup-sqlserver/SqlServerExtensions.cs
+++ b/src/dbup-sqlserver/SqlServerExtensions.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Data;
+#if USE_MSSQLCLIENT
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using DbUp;
 using DbUp.Builder;
 using DbUp.Engine.Output;

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -4,7 +4,7 @@
     <Description>DbUp makes it easy to deploy and upgrade SQL Server databases by running change scripts.</Description>
     <Title>DbUp MS Sql Server Support</Title>
     <Authors>Paul Stovell;Jim Burger;Jake Ginnivan;Damian Maclennan</Authors>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net35;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net35;net46;net5.0</TargetFrameworks>
     <AssemblyName>dbup-sqlserver</AssemblyName>
     <AssemblyOriginatorKeyFile>../dbup.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -42,6 +42,11 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
   </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.0" />
+        <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
+    </ItemGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' ">
     <DefineConstants>$(DefineConstants);SUPPORTS_SQL_CONTEXT</DefineConstants>
   </PropertyGroup>
@@ -53,5 +58,9 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);SUPPORTS_AZURE_AD</DefineConstants>
   </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+        <DefineConstants>$(DefineConstants);USE_MSSQLCLIENT</DefineConstants>
+    </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Replacing NuGet package  `System.Data.SqlClient` with `Microsoft.Data.SqlClient`. See issue #546 