### PR TITLE
Enable Alternate Azure SQL Instances

### DIFF
--- a/src/dbup-sqlserver/AzureSqlConnectionManager.cs
+++ b/src/dbup-sqlserver/AzureSqlConnectionManager.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.Data.SqlClient;
+using DbUp.Engine.Transactions;
+using DbUp.Support;
+
+#if SUPPORTS_AZURE_AD
+using Microsoft.Azure.Services.AppAuthentication;
+
+namespace DbUp.SqlServer
+{
+    /// <summary>Manages an Azure Sql Server database connection.</summary>
+    public class AzureSqlConnectionManager : DatabaseConnectionManager
+    {
+        public AzureSqlConnectionManager(string connectionString)
+            : this(connectionString, "https://database.windows.net/", null)
+        { }
+
+        public AzureSqlConnectionManager(string connectionString, string resource)
+            : this(connectionString, resource, null)
+        { }
+
+        public AzureSqlConnectionManager(string connectionString, string resource, string tenantId, string azureAdInstance = "https://login.microsoftonline.com/")
+            : base(new DelegateConnectionFactory((log, dbManager) =>
+            {
+                var conn = new SqlConnection(connectionString)
+                {
+                    AccessToken = new AzureServiceTokenProvider(azureAdInstance: azureAdInstance).GetAccessTokenAsync(resource, tenantId)
+                                                                                                 .ConfigureAwait(false)
+                                                                                                 .GetAwaiter()
+                                                                                                 .GetResult()
+                };
+
+                if (dbManager.IsScriptOutputLogged)
+                    conn.InfoMessage += (sender, e) => log.WriteInformation($"{{0}}", e.Message);
+
+                return conn;
+            }))
+        { }
+
+        public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
+        {
+            var commandSplitter = new SqlCommandSplitter();
+            var scriptStatements = commandSplitter.SplitScriptIntoCommands(scriptContents);
+            return scriptStatements;
+        }
+    }
+}
+#endif

--- a/src/dbup-sqlserver/AzureSqlServerExtensions.cs
+++ b/src/dbup-sqlserver/AzureSqlServerExtensions.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using DbUp.Builder;
+using DbUp.SqlServer;
+
+#if SUPPORTS_AZURE_AD
+
+/// <summary>Configuration extension methods for Azure SQL Server.</summary>
+// NOTE: DO NOT MOVE THIS TO A NAMESPACE
+// Since the class just contains extension methods, we leave it in the global:: namespace so that it is always available
+// ReSharper disable CheckNamespace
+public static class AzureSqlServerExtensions
+{
+    /// <summary>Creates an upgrader for SQL Server databases.</summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
+    /// <param name="useAzureSqlIntegratedSecurity">Whether to use Azure SQL Integrated Security</param>
+    /// <returns>A builder for a database upgrader designed for SQL Server databases.</returns>
+    [Obsolete("Use \"AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases, string, string)\" if passing \"true\" to \"useAzureSqlIntegratedSecurity\".")]
+    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity)
+    {
+        if (useAzureSqlIntegratedSecurity)
+        {
+            return AzureSqlDatabaseWithIntegratedSecurity(supported, connectionString, schema);
+        }
+
+        return supported.SqlDatabase(new SqlConnectionManager(connectionString), schema);
+    }
+
+    /// <summary>Creates an upgrader for Azure SQL Databases using Azure AD Integrated Security.</summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
+    /// <returns>A builder for a database upgrader designed for Azure SQL Server databases.</returns>
+    public static UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases supported, string connectionString, string schema)
+    {
+        return supported.SqlDatabase(new AzureSqlConnectionManager(connectionString), schema);
+    }
+
+    /// <summary>Creates an upgrader for Azure SQL Databases using Azure AD Integrated Security.</summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
+    /// <returns>A builder for a database upgrader designed for Azure SQL Server databases.</returns>
+    public static UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases supported, string connectionString, string schema, string resource)
+    {
+        return AzureSqlDatabaseWithIntegratedSecurity(supported, connectionString, schema, resource, null);
+    }
+
+    /// <summary>Creates an upgrader for Azure SQL Databases using Azure AD Integrated Security.</summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
+    /// <param name="resource">Resource to access. e.g. https://management.azure.com/.</param>
+    /// <param name="tenantId">If not specified, default tenant is used. Managed Service Identity REST protocols do not accept tenantId, so this can only be used with certificate and client secret based authentication.</param>
+    /// <param name="azureAdInstance">Specify a value for clouds other than the Public Cloud.</param>
+    /// <returns>A builder for a database upgrader designed for Azure SQL Server databases.</returns>
+    public static UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases supported, string connectionString, string schema, string resource, string tenantId, string azureAdInstance = "https://login.microsoftonline.com/")
+    {
+        return supported.SqlDatabase(new AzureSqlConnectionManager(connectionString, resource, tenantId, azureAdInstance), schema);
+    }
+}
+
+#endif

--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data.SqlClient;
 using DbUp.Engine.Transactions;
 using DbUp.Support;
-#if SUPPORTS_AZURE_AD
-using Microsoft.Azure.Services.AppAuthentication;
-#endif
 
 namespace DbUp.SqlServer
 {
@@ -28,31 +24,7 @@ namespace DbUp.SqlServer
 
                  return conn;
              }))
-        {
-        }
-
-#if SUPPORTS_AZURE_AD
-        /// <summary>
-        /// Manages Sql Database Connections
-        /// </summary>
-        /// <param name="connectionString"></param>
-        /// <param name="useAzureSqlIntegratedSecurity">Whether to use Azure SQL Integrated Sercurity</param>
-        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity)
-            : base(new DelegateConnectionFactory((log, dbManager) =>
-            {
-                var conn = new SqlConnection(connectionString);
-
-                if (useAzureSqlIntegratedSecurity)
-                    conn.AccessToken = new AzureServiceTokenProvider().GetAccessTokenAsync("https://database.windows.net/").ConfigureAwait(false).GetAwaiter().GetResult();
-
-                if (dbManager.IsScriptOutputLogged)
-                    conn.InfoMessage += (sender, e) => log.WriteInformation($"{{0}}", e.Message);
-
-                return conn;
-            }))
-        {
-        }
-#endif
+        { }
 
         public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
         {

--- a/src/dbup-sqlserver/SqlServerExtensions.cs
+++ b/src/dbup-sqlserver/SqlServerExtensions.cs
@@ -43,61 +43,6 @@ public static class SqlServerExtensions
         return SqlDatabase(new SqlConnectionManager(connectionString), schema);
     }
 
-#if SUPPORTS_AZURE_AD
-    /// <summary>
-    /// Creates an upgrader for SQL Server databases.
-    /// </summary>
-    /// <param name="supported">Fluent helper type.</param>
-    /// <param name="connectionString">The connection string.</param>
-    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
-    /// <param name="useAzureSqlIntegratedSecurity">Whether to use Azure SQL Integrated Security</param>
-    /// <returns>
-    /// A builder for a database upgrader designed for SQL Server databases.
-    /// </returns>
-    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity)
-    {
-        if (useAzureSqlIntegratedSecurity)
-        {
-            return AzureSqlDatabaseWithIntegratedSecurity(supported, connectionString, schema);
-        }
-
-        return SqlDatabase(new SqlConnectionManager(connectionString), schema);
-    }
-
-    /// <summary>Creates an upgrader for Azure SQL Databases using Azure AD Integrated Security.</summary>
-    /// <param name="supported">Fluent helper type.</param>
-    /// <param name="connectionString">The connection string.</param>
-    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
-    /// <returns>A builder for a database upgrader designed for Azure SQL Server databases.</returns>
-    public static UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases supported, string connectionString, string schema)
-    {
-        return SqlDatabase(new AzureSqlConnectionManager(connectionString), schema);
-    }
-
-    /// <summary>Creates an upgrader for Azure SQL Databases using Azure AD Integrated Security.</summary>
-    /// <param name="supported">Fluent helper type.</param>
-    /// <param name="connectionString">The connection string.</param>
-    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
-    /// <returns>A builder for a database upgrader designed for Azure SQL Server databases.</returns>
-    public static UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases supported, string connectionString, string schema, string resource)
-    {
-        return AzureSqlDatabaseWithIntegratedSecurity(supported, connectionString, schema, resource, null);
-    }
-
-    /// <summary>Creates an upgrader for Azure SQL Databases using Azure AD Integrated Security.</summary>
-    /// <param name="supported">Fluent helper type.</param>
-    /// <param name="connectionString">The connection string.</param>
-    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
-    /// <param name="azureAdInstance">Specify a value for clouds other than the Public Cloud.</param>
-    /// <param name="resource">Resource to access. e.g. https://management.azure.com/.</param>
-    /// <param name="tenantId">If not specified, default tenant is used. Managed Service Identity REST protocols do not accept tenantId, so this can only be used with certificate and client secret based authentication.</param>
-    /// <returns>A builder for a database upgrader designed for Azure SQL Server databases.</returns>
-    public static UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases supported, string connectionString, string schema, string resource, string tenantId, string azureAdInstance = "https://login.microsoftonline.com/")
-    {
-        return SqlDatabase(new AzureSqlConnectionManager(connectionString, azureAdInstance, resource, tenantId), schema);
-    }
-#endif
-
     /// <summary>
     /// Creates an upgrader for SQL Server databases.
     /// </summary>

--- a/src/dbup-sqlserver/SqlServerExtensions.cs
+++ b/src/dbup-sqlserver/SqlServerExtensions.cs
@@ -49,14 +49,52 @@ public static class SqlServerExtensions
     /// </summary>
     /// <param name="supported">Fluent helper type.</param>
     /// <param name="connectionString">The connection string.</param>
-    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if null.</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
     /// <param name="useAzureSqlIntegratedSecurity">Whether to use Azure SQL Integrated Security</param>
     /// <returns>
     /// A builder for a database upgrader designed for SQL Server databases.
     /// </returns>
     public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity)
     {
-        return SqlDatabase(new SqlConnectionManager(connectionString, useAzureSqlIntegratedSecurity), schema);
+        if (useAzureSqlIntegratedSecurity)
+        {
+            return AzureSqlDatabaseWithIntegratedSecurity(supported, connectionString, schema);
+        }
+
+        return SqlDatabase(new SqlConnectionManager(connectionString), schema);
+    }
+
+    /// <summary>Creates an upgrader for Azure SQL Databases using Azure AD Integrated Security.</summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
+    /// <returns>A builder for a database upgrader designed for Azure SQL Server databases.</returns>
+    public static UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases supported, string connectionString, string schema)
+    {
+        return SqlDatabase(new AzureSqlConnectionManager(connectionString), schema);
+    }
+
+    /// <summary>Creates an upgrader for Azure SQL Databases using Azure AD Integrated Security.</summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
+    /// <returns>A builder for a database upgrader designed for Azure SQL Server databases.</returns>
+    public static UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases supported, string connectionString, string schema, string resource)
+    {
+        return AzureSqlDatabaseWithIntegratedSecurity(supported, connectionString, schema, resource, null);
+    }
+
+    /// <summary>Creates an upgrader for Azure SQL Databases using Azure AD Integrated Security.</summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
+    /// <param name="azureAdInstance">Specify a value for clouds other than the Public Cloud.</param>
+    /// <param name="resource">Resource to access. e.g. https://management.azure.com/.</param>
+    /// <param name="tenantId">If not specified, default tenant is used. Managed Service Identity REST protocols do not accept tenantId, so this can only be used with certificate and client secret based authentication.</param>
+    /// <returns>A builder for a database upgrader designed for Azure SQL Server databases.</returns>
+    public static UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases supported, string connectionString, string schema, string resource, string tenantId, string azureAdInstance = "https://login.microsoftonline.com/")
+    {
+        return SqlDatabase(new AzureSqlConnectionManager(connectionString, azureAdInstance, resource, tenantId), schema);
     }
 #endif
 

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
@@ -1,15 +1,19 @@
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("8190b40b-ac5b-414f-8a00-9b6a2c12b010")]
 
-public static class SqlServerExtensions
+public static class AzureSqlServerExtensions
 {
     public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string resource) { }
     public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string resource, string tenantId, string azureAdInstance = "https://login.microsoftonline.com/") { }
+    [System.ObsoleteAttribute("Use "AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases, string, string)" if passing "true" to "useAzureSqlIntegratedSecurity".")]
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity) { }
+}
+public static class SqlServerExtensions
+{
     public static DbUp.Builder.UpgradeEngineBuilder JournalToSqlTable(this DbUp.Builder.UpgradeEngineBuilder builder, string schema, string table) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
-    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema = null) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.SqlServer.AzureDatabaseEdition azureDatabaseEdition) { }

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
@@ -3,6 +3,9 @@
 
 public static class SqlServerExtensions
 {
+    public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
+    public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string resource) { }
+    public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string resource, string tenantId, string azureAdInstance = "https://login.microsoftonline.com/") { }
     public static DbUp.Builder.UpgradeEngineBuilder JournalToSqlTable(this DbUp.Builder.UpgradeEngineBuilder builder, string schema, string table) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
@@ -30,10 +33,16 @@ namespace DbUp.SqlServer
         Standard = 2
         Premium = 3
     }
+    public class AzureSqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
+    {
+        public AzureSqlConnectionManager(string connectionString) { }
+        public AzureSqlConnectionManager(string connectionString, string resource) { }
+        public AzureSqlConnectionManager(string connectionString, string resource, string tenantId, string azureAdInstance = "https://login.microsoftonline.com/") { }
+        public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
+    }
     public class SqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
         public SqlConnectionManager(string connectionString) { }
-        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class SqlScriptExecutor : DbUp.Support.ScriptExecutor, DbUp.Engine.IScriptExecutor

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
@@ -1,16 +1,20 @@
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("8190b40b-ac5b-414f-8a00-9b6a2c12b010")]
 
-public static class SqlServerExtensions
+public static class AzureSqlServerExtensions
 {
     public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string resource) { }
     public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string resource, string tenantId, string azureAdInstance = "https://login.microsoftonline.com/") { }
+    [System.ObsoleteAttribute("Use "AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases, string, string)" if passing "true" to "useAzureSqlIntegratedSecurity".")]
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity) { }
+}
+public static class SqlServerExtensions
+{
     public static DbUp.Builder.UpgradeEngineBuilder JournalToSqlTable(this DbUp.Builder.UpgradeEngineBuilder builder, string schema, string table) { }
     public static DbUp.Builder.UpgradeEngineBuilder LogToSqlContext(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
-    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema = null) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.SqlServer.AzureDatabaseEdition azureDatabaseEdition) { }

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
@@ -3,6 +3,9 @@
 
 public static class SqlServerExtensions
 {
+    public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
+    public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string resource) { }
+    public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string resource, string tenantId, string azureAdInstance = "https://login.microsoftonline.com/") { }
     public static DbUp.Builder.UpgradeEngineBuilder JournalToSqlTable(this DbUp.Builder.UpgradeEngineBuilder builder, string schema, string table) { }
     public static DbUp.Builder.UpgradeEngineBuilder LogToSqlContext(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
@@ -31,10 +34,16 @@ namespace DbUp.SqlServer
         Standard = 2
         Premium = 3
     }
+    public class AzureSqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
+    {
+        public AzureSqlConnectionManager(string connectionString) { }
+        public AzureSqlConnectionManager(string connectionString, string resource) { }
+        public AzureSqlConnectionManager(string connectionString, string resource, string tenantId, string azureAdInstance = "https://login.microsoftonline.com/") { }
+        public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
+    }
     public class SqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
         public SqlConnectionManager(string connectionString) { }
-        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class SqlScriptExecutor : DbUp.Support.ScriptExecutor, DbUp.Engine.IScriptExecutor


### PR DESCRIPTION
Certain alternate Azure SQL Instances, such as those specifically for Government use, need additional configuration to be passed through to the Azure Service Token Provider in order to properly connect.

This change implements additional extension methods which accept the specialised parameters to allow the connection to be properly set up.

Fixes #555 "Add Azure Gov as option for Azure Sql Integrated Security"