### PR TITLE
Add SQLite journal extension

### DIFF
--- a/src/dbup-postgresql/PostgresqlExtensions.cs
+++ b/src/dbup-postgresql/PostgresqlExtensions.cs
@@ -207,7 +207,7 @@ public static class PostgresqlExtensions
     }
 
     /// <summary>
-    /// Tracks the list of executed scripts in a SQL Server table.
+    /// Tracks the list of executed scripts in a PostgreSQL table.
     /// </summary>
     /// <param name="builder">The builder.</param>
     /// <param name="schema">The schema.</param>

--- a/src/dbup-sqlite/SqliteExtensions.cs
+++ b/src/dbup-sqlite/SqliteExtensions.cs
@@ -49,4 +49,17 @@ public static class SQLiteExtensions
         builder.WithPreprocessor(new SQLitePreprocessor());
         return builder;
     }
+    
+    /// <summary>
+    /// Tracks the list of executed scripts in a SQLite table.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="schema">The schema.</param>
+    /// <param name="table">The table.</param>
+    /// <returns></returns>
+    public static UpgradeEngineBuilder JournalToSQLiteTable(this UpgradeEngineBuilder builder, string table)
+    {
+        builder.Configure(c => c.Journal = new SQLiteTableJournal(() => c.ConnectionManager, () => c.Log, table));
+        return builder;
+    }
 }

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlite.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlite.approved.cs
@@ -6,6 +6,7 @@ public static class SQLiteExtensions
 {
     public static DbUp.Builder.UpgradeEngineBuilder SQLiteDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SQLiteDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.SQLite.Helpers.SharedConnection sharedConnection) { }
+    public static DbUp.Builder.UpgradeEngineBuilder JournalToSQLiteTable(this DbUp.Builder.UpgradeEngineBuilder builder, string table) { }
 }
 namespace DbUp.SQLite
 {


### PR DESCRIPTION
This PR adds an extension/helper method so SQLite databases can use the same fluid builder syntax as SQL Server, PostgreSQL, and Redshift.

It also fixes the comment from the PostgreSQL version, which I'm assuming was copied and pasted from SQL Server (as I did for the SQLite one :sweat_smile:)

I noticed the existing methods had no test coverage, so lmk if you'd like that added!