### PR TITLE
Add support for Microsoft.Data.SqlClient

### DIFF
--- a/src/dbup-sqlserver/AzureSqlConnectionManager.cs
+++ b/src/dbup-sqlserver/AzureSqlConnectionManager.cs
@@ -1,5 +1,9 @@
 ﻿using System.Collections.Generic;
+#if SUPPORTS_MICROSOFT_SQLCLIENT
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using DbUp.Engine.Transactions;
 using DbUp.Support;
 

--- a/src/dbup-sqlserver/Helpers/TemporarySqlDatabase.cs
+++ b/src/dbup-sqlserver/Helpers/TemporarySqlDatabase.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+#if SUPPORTS_MICROSOFT_SQLCLIENT
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using DbUp.Helpers;
 
 namespace DbUp.SqlServer.Helpers

--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -1,5 +1,9 @@
 ﻿using System.Collections.Generic;
+#if SUPPORTS_MICROSOFT_SQLCLIENT
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using DbUp.Engine.Transactions;
 using DbUp.Support;
 

--- a/src/dbup-sqlserver/SqlScriptExecutor.cs
+++ b/src/dbup-sqlserver/SqlScriptExecutor.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+#if SUPPORTS_MICROSOFT_SQLCLIENT
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using DbUp.Engine;
 using DbUp.Engine.Output;
 using DbUp.Engine.Transactions;

--- a/src/dbup-sqlserver/SqlServerExtensions.cs
+++ b/src/dbup-sqlserver/SqlServerExtensions.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Data;
+#if SUPPORTS_MICROSOFT_SQLCLIENT
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using DbUp;
 using DbUp.Builder;
 using DbUp.Engine.Output;

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -24,21 +24,22 @@
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' Or '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
     <Reference Include="System.Data" />
     <Reference Include="System" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
   </ItemGroup>
-
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
   </ItemGroup>
-
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
   </ItemGroup>
 
@@ -47,11 +48,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_SQL_CONTEXT;SUPPORTS_AZURE_AD</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_SQL_CONTEXT;SUPPORTS_AZURE_AD;SUPPORTS_MICROSOFT_SQLCLIENT</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_AZURE_AD</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_AZURE_AD;SUPPORTS_MICROSOFT_SQLCLIENT</DefineConstants>
   </PropertyGroup>
 
 </Project>

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' Or '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Data" />
     <Reference Include="System" />
   </ItemGroup>

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -33,11 +33,9 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
   </ItemGroup>
-  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
   </ItemGroup>
-  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
@@ -74,7 +74,12 @@ namespace DbUp.SqlServer.Helpers
     {
         public TemporarySqlDatabase(string name) { }
         public TemporarySqlDatabase(string name, string instanceName) { }
+#if SUPPORTS_MICROSOFT_SQLCLIENT
+        public TemporarySqlDatabase(Microsoft.Data.SqlClient.SqlConnectionStringBuilder connectionStringBuilder) { }
+#else
         public TemporarySqlDatabase(System.Data.SqlClient.SqlConnectionStringBuilder connectionStringBuilder) { }
+#endif
+
         public DbUp.Helpers.AdHocSqlRunner AdHoc { get; }
         public string ConnectionString { get; }
         public void Create() { }

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
@@ -1,4 +1,4 @@
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+﻿[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("8190b40b-ac5b-414f-8a00-9b6a2c12b010")]
 
 public static class AzureSqlServerExtensions
@@ -74,12 +74,7 @@ namespace DbUp.SqlServer.Helpers
     {
         public TemporarySqlDatabase(string name) { }
         public TemporarySqlDatabase(string name, string instanceName) { }
-#if SUPPORTS_MICROSOFT_SQLCLIENT
-        public TemporarySqlDatabase(Microsoft.Data.SqlClient.SqlConnectionStringBuilder connectionStringBuilder) { }
-#else
-        public TemporarySqlDatabase(System.Data.SqlClient.SqlConnectionStringBuilder connectionStringBuilder) { }
-#endif
-
+        public TemporarySqlDatabase(SqlConnectionStringBuilder connectionStringBuilder) { }
         public DbUp.Helpers.AdHocSqlRunner AdHoc { get; }
         public string ConnectionString { get; }
         public void Create() { }

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
@@ -74,7 +74,7 @@ namespace DbUp.SqlServer.Helpers
     {
         public TemporarySqlDatabase(string name) { }
         public TemporarySqlDatabase(string name, string instanceName) { }
-        public TemporarySqlDatabase(SqlConnectionStringBuilder connectionStringBuilder) { }
+        public TemporarySqlDatabase(Microsoft.Data.SqlClient.SqlConnectionStringBuilder connectionStringBuilder) { }
         public DbUp.Helpers.AdHocSqlRunner AdHoc { get; }
         public string ConnectionString { get; }
         public void Create() { }

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
@@ -47,7 +47,7 @@ namespace DbUp.SqlServer
     }
     public class SqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
-        public  Manager(string connectionString) { }
+        public SqlConnectionManager(string connectionString) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class SqlScriptExecutor : DbUp.Support.ScriptExecutor, DbUp.Engine.IScriptExecutor

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
@@ -1,4 +1,4 @@
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+﻿[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("8190b40b-ac5b-414f-8a00-9b6a2c12b010")]
 
 public static class AzureSqlServerExtensions
@@ -47,7 +47,7 @@ namespace DbUp.SqlServer
     }
     public class SqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
-        public SqlConnectionManager(string connectionString) { }
+        public  Manager(string connectionString) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class SqlScriptExecutor : DbUp.Support.ScriptExecutor, DbUp.Engine.IScriptExecutor
@@ -75,11 +75,7 @@ namespace DbUp.SqlServer.Helpers
     {
         public TemporarySqlDatabase(string name) { }
         public TemporarySqlDatabase(string name, string instanceName) { }
-#if SUPPORTS_MICROSOFT_SQLCLIENT
-        public TemporarySqlDatabase(Microsoft.Data.SqlClient.SqlConnectionStringBuilder connectionStringBuilder) { }
-#else
-        public TemporarySqlDatabase(System.Data.SqlClient.SqlConnectionStringBuilder connectionStringBuilder) { }
-#endif
+        public TemporarySqlDatabase(SqlConnectionStringBuilder connectionStringBuilder) { }
         public DbUp.Helpers.AdHocSqlRunner AdHoc { get; }
         public string ConnectionString { get; }
         public void Create() { }

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
@@ -75,7 +75,7 @@ namespace DbUp.SqlServer.Helpers
     {
         public TemporarySqlDatabase(string name) { }
         public TemporarySqlDatabase(string name, string instanceName) { }
-        public TemporarySqlDatabase(SqlConnectionStringBuilder connectionStringBuilder) { }
+        public TemporarySqlDatabase(Microsoft.Data.SqlClient.SqlConnectionStringBuilder connectionStringBuilder) { }
         public DbUp.Helpers.AdHocSqlRunner AdHoc { get; }
         public string ConnectionString { get; }
         public void Create() { }

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
@@ -75,7 +75,11 @@ namespace DbUp.SqlServer.Helpers
     {
         public TemporarySqlDatabase(string name) { }
         public TemporarySqlDatabase(string name, string instanceName) { }
+#if SUPPORTS_MICROSOFT_SQLCLIENT
+        public TemporarySqlDatabase(Microsoft.Data.SqlClient.SqlConnectionStringBuilder connectionStringBuilder) { }
+#else
         public TemporarySqlDatabase(System.Data.SqlClient.SqlConnectionStringBuilder connectionStringBuilder) { }
+#endif
         public DbUp.Helpers.AdHocSqlRunner AdHoc { get; }
         public string ConnectionString { get; }
         public void Create() { }


### PR DESCRIPTION
System.Data.SqlClient is now moved to Microsoft.Data.SqlClient and while System.Data.SqlClient still works all new development is in the new library as per the GitHub page [https://github.com/dotnet/SqlClient](https://github.com/dotnet/SqlClient). The upgrade is simple as it is just namespace changes however the new library only supports .NetStandard 2.0 and .Net Framework 4.6. I have added a new compile flag to allow for backwards compatibility of .Net 3.5 and .NetStandard 1.3 as they will continue to use their current methods of accessing SqlClient.

The feature I'm after is provided in the latest release in Microsoft.Data.SqlClient 2.1 called Azure Active Directory Managed Identity authentication it just requires a property in the connection string to allow managed Identity access to Azure sql server [https://github.com/dotnet/SqlClient/blob/master/release-notes/2.1/2.1.0.md](https://github.com/dotnet/SqlClient/blob/master/release-notes/2.1/2.1.0.md)

