### PR TITLE
Support spaces between connection string separators [;=]

### DIFF
--- a/src/dbup-mysql/MySqlExtensions.cs
+++ b/src/dbup-mysql/MySqlExtensions.cs
@@ -24,9 +24,9 @@ public static class MySqlExtensions
     /// </returns>
     public static UpgradeEngineBuilder MySqlDatabase(this SupportedDatabases supported, string connectionString)
     {
-        foreach (var pair in connectionString.Split(';').Select(s => s.Split('=')).Where(pair => pair.Length == 2).Where(pair => pair[0].ToLower() == "database"))
+        foreach (var pair in connectionString.Split(';').Select(s => s.Split('=')).Where(pair => pair.Length == 2).Where(pair => pair[0].Trim().ToLower() == "database"))
         {
-            return MySqlDatabase(new MySqlConnectionManager(connectionString), pair[1]);
+            return MySqlDatabase(new MySqlConnectionManager(connectionString), pair[1].Trim());
         }
 
         return MySqlDatabase(new MySqlConnectionManager(connectionString));

--- a/src/dbup-oracle/OracleExtensions.cs
+++ b/src/dbup-oracle/OracleExtensions.cs
@@ -10,9 +10,9 @@ namespace DbUp.Oracle
         [Obsolete("Use OracleDatabaseWithSlashDelimiter, OracleDatabaseWithSemicolonDelimiter or the OracleDatabase with the delimiter parameter instead, see https://github.com/DbUp/DbUp/pull/335")]
         public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, string connectionString)
         {
-            foreach (var pair in connectionString.Split(';').Select(s => s.Split('=')).Where(pair => pair.Length == 2).Where(pair => pair[0].ToLower() == "database"))
+            foreach (var pair in connectionString.Split(';').Select(s => s.Split('=')).Where(pair => pair.Length == 2).Where(pair => pair[0].Trim().ToLower() == "database"))
             {
-                return OracleDatabase(new OracleConnectionManager(connectionString), pair[1]);
+                return OracleDatabase(new OracleConnectionManager(connectionString), pair[1].Trim());
             }
 
             return OracleDatabase(new OracleConnectionManager(connectionString));
@@ -38,9 +38,9 @@ namespace DbUp.Oracle
 
         public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, string connectionString, char delimiter)
         {
-            foreach (var pair in connectionString.Split(';').Select(s => s.Split('=')).Where(pair => pair.Length == 2).Where(pair => pair[0].ToLower() == "database"))
+            foreach (var pair in connectionString.Split(';').Select(s => s.Split('=')).Where(pair => pair.Length == 2).Where(pair => pair[0].Trim().ToLower() == "database"))
             {
-                return OracleDatabase(new OracleConnectionManager(connectionString, new OracleCommandSplitter(delimiter)), pair[1]);
+                return OracleDatabase(new OracleConnectionManager(connectionString, new OracleCommandSplitter(delimiter)), pair[1].Trim());
             }
 
             return OracleDatabase(new OracleConnectionManager(connectionString, new OracleCommandSplitter(delimiter)));


### PR DESCRIPTION
I recently ran into a _bug_ where DbUp wasn't creating the `schemaversions` table on my schema cause it was finding another `schemaversions` in another schema. 

Turns out my connection string looked something like this:

```
data source=dbserver.com; database=myschema
```

That ` ` (space) after `;` was causing the `TableJournal` to not recognize the explicit schema. This PR fixes that bug and also accounts for potential spaces on the value-side of the database (i.e. `; database = myschema`). 