### PR TITLE
Update Npgsql 3.2.6 -> 3.2.7 to enable SCRAM-SHA-256 auth support

### DIFF
--- a/src/dbup-postgresql/dbup-postgresql.csproj
+++ b/src/dbup-postgresql/dbup-postgresql.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net35'">
-    <PackageReference Include="Npgsql" Version="3.2.6" />
+    <PackageReference Include="Npgsql" Version="3.2.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
SCRAM-SHA-256 is a recommended auth mode since postgresql 10 that replaces md5.

See https://github.com/npgsql/npgsql/issues/1530