### PR TITLE
Allow usage of an existing sql connection

### DIFF
--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -15,15 +15,7 @@ namespace DbUp.SqlServer
         /// </summary>
         /// <param name="connectionString"></param>
         public SqlConnectionManager(string connectionString)
-             : base(new DelegateConnectionFactory((log, dbManager) =>
-             {
-                 var conn = new SqlConnection(connectionString);
-
-                 if (dbManager.IsScriptOutputLogged)
-                     conn.InfoMessage += (sender, e) => log.WriteInformation($"{{0}}", e.Message);
-
-                 return conn;
-             }))
+             : this(new SqlConnection(connectionString))
         { }
 
         public SqlConnectionManager(SqlConnection connection)

--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -26,6 +26,16 @@ namespace DbUp.SqlServer
              }))
         { }
 
+        public SqlConnectionManager(SqlConnection connection)
+               : base(new DelegateConnectionFactory((log, dbManager) =>
+               {
+                   if (dbManager.IsScriptOutputLogged)
+                       connection.InfoMessage += (sender, e) => log.WriteInformation($"{{0}}", e.Message);
+
+                   return connection;
+               }))
+        { }
+
         public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
         {
             var commandSplitter = new SqlCommandSplitter();

--- a/src/dbup-sqlserver/SqlServerExtensions.cs
+++ b/src/dbup-sqlserver/SqlServerExtensions.cs
@@ -33,6 +33,19 @@ public static class SqlServerExtensions
     /// Creates an upgrader for SQL Server databases.
     /// </summary>
     /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connection">The sql connection.</param>
+    /// <returns>
+    /// A builder for a database upgrader designed for SQL Server databases.
+    /// </returns>
+    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, SqlConnection connection)
+    {
+        return SqlDatabase(supported, connection, null);
+    }
+
+    /// <summary>
+    /// Creates an upgrader for SQL Server databases.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
     /// <param name="connectionString">The connection string.</param>
     /// <param name="schema">The SQL schema name to use. Defaults to 'dbo'.</param>
     /// <returns>
@@ -41,6 +54,20 @@ public static class SqlServerExtensions
     public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, string connectionString, string schema)
     {
         return SqlDatabase(new SqlConnectionManager(connectionString), schema);
+    }
+
+    /// <summary>
+    /// Creates an upgrader for SQL Server databases.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connection">The sql connection.</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo'.</param>
+    /// <returns>
+    /// A builder for a database upgrader designed for SQL Server databases.
+    /// </returns>
+    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, SqlConnection connection, string schema)
+    {
+        return SqlDatabase(new SqlConnectionManager(connection), schema);
     }
 
     /// <summary>

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
@@ -1,4 +1,4 @@
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+﻿[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("8190b40b-ac5b-414f-8a00-9b6a2c12b010")]
 
 public static class AzureSqlServerExtensions
@@ -15,6 +15,8 @@ public static class SqlServerExtensions
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema = null) { }
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, SqlConnection connection) { }
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, string connectionString, string schema) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForDropDatabase supported, string connectionString) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.SqlServer.AzureDatabaseEdition azureDatabaseEdition) { }
@@ -47,6 +49,7 @@ namespace DbUp.SqlServer
     public class SqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
         public SqlConnectionManager(string connectionString) { }
+        public SqlConnectionManager(SqlConnection connection) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class SqlScriptExecutor : DbUp.Support.ScriptExecutor, DbUp.Engine.IScriptExecutor

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
@@ -1,4 +1,4 @@
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+﻿[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("8190b40b-ac5b-414f-8a00-9b6a2c12b010")]
 
 public static class AzureSqlServerExtensions
@@ -16,6 +16,8 @@ public static class SqlServerExtensions
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema = null) { }
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, SqlConnection connection) { }
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, string connectionString, string schema) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForDropDatabase supported, string connectionString) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.SqlServer.AzureDatabaseEdition azureDatabaseEdition) { }
@@ -48,6 +50,7 @@ namespace DbUp.SqlServer
     public class SqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
         public SqlConnectionManager(string connectionString) { }
+        public SqlConnectionManager(SqlConnection connection) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class SqlScriptExecutor : DbUp.Support.ScriptExecutor, DbUp.Engine.IScriptExecutor


### PR DESCRIPTION
Updated `SqlConnectionManager` and `SqlServerExtensions` to allow an existing SqlConnection to be used for migrating.