### PR TITLE
Update NuGet project URLs

### DIFF
--- a/src/dbup-core/dbup-core.csproj
+++ b/src/dbup-core/dbup-core.csproj
@@ -13,7 +13,7 @@
     <PackageId>dbup-core</PackageId>
     <PackageReleaseNotes>https://github.com/DbUp/DbUp/releases</PackageReleaseNotes>
     <PackageIconUrl>https://raw.github.com/DbUp/DbUp/master/src/Information/dbup-icon.png</PackageIconUrl>
-    <PackageProjectUrl>http://dbup.github.com</PackageProjectUrl>
+    <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.opensource.org/licenses/mit-license.php</PackageLicenseUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/dbup-firebird/dbup-firebird.csproj
+++ b/src/dbup-firebird/dbup-firebird.csproj
@@ -12,7 +12,7 @@
     <PackageId>dbup-firebird</PackageId>
     <PackageReleaseNotes>https://github.com/DbUp/DbUp/releases</PackageReleaseNotes>
     <PackageIconUrl>https://raw.github.com/DbUp/DbUp/master/src/Information/dbup-icon.png</PackageIconUrl>
-    <PackageProjectUrl>http://dbup.github.com</PackageProjectUrl>
+    <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.opensource.org/licenses/mit-license.php</PackageLicenseUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/dbup-mysql/dbup-mysql.csproj
+++ b/src/dbup-mysql/dbup-mysql.csproj
@@ -12,7 +12,7 @@
     <PackageId>dbup-mysql</PackageId>
     <PackageReleaseNotes>https://github.com/DbUp/DbUp/releases</PackageReleaseNotes>
     <PackageIconUrl>https://raw.github.com/DbUp/DbUp/master/src/Information/dbup-icon.png</PackageIconUrl>
-    <PackageProjectUrl>http://dbup.github.com</PackageProjectUrl>
+    <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.opensource.org/licenses/mit-license.php</PackageLicenseUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/dbup-postgresql/dbup-postgresql.csproj
+++ b/src/dbup-postgresql/dbup-postgresql.csproj
@@ -12,7 +12,7 @@
     <PackageId>dbup-postgresql</PackageId>
     <PackageReleaseNotes>https://github.com/DbUp/DbUp/releases</PackageReleaseNotes>
     <PackageIconUrl>https://raw.github.com/DbUp/DbUp/master/src/Information/dbup-icon.png</PackageIconUrl>
-    <PackageProjectUrl>http://dbup.github.com</PackageProjectUrl>
+    <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.opensource.org/licenses/mit-license.php</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/src/dbup-redshift/dbup-redshift.csproj
+++ b/src/dbup-redshift/dbup-redshift.csproj
@@ -12,7 +12,7 @@
     <PackageId>dbup-redshift</PackageId>
     <PackageReleaseNotes>https://github.com/DbUp/DbUp/releases</PackageReleaseNotes>
     <PackageIconUrl>https://raw.github.com/DbUp/DbUp/master/src/Information/dbup-icon.png</PackageIconUrl>
-    <PackageProjectUrl>http://dbup.github.com</PackageProjectUrl>
+    <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.opensource.org/licenses/mit-license.php</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/src/dbup-sqlce/dbup-sqlce.csproj
+++ b/src/dbup-sqlce/dbup-sqlce.csproj
@@ -12,7 +12,7 @@
     <PackageId>dbup-sqlce</PackageId>
     <PackageReleaseNotes>https://github.com/DbUp/DbUp/releases</PackageReleaseNotes>
     <PackageIconUrl>https://raw.github.com/DbUp/DbUp/master/src/Information/dbup-icon.png</PackageIconUrl>
-    <PackageProjectUrl>http://dbup.github.com</PackageProjectUrl>
+    <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.opensource.org/licenses/mit-license.php</PackageLicenseUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/dbup-sqlite-mono/dbup-sqlite-mono.csproj
+++ b/src/dbup-sqlite-mono/dbup-sqlite-mono.csproj
@@ -12,7 +12,7 @@
     <PackageId>dbup-sqlite-mono</PackageId>
     <PackageReleaseNotes>https://github.com/DbUp/DbUp/releases</PackageReleaseNotes>
     <PackageIconUrl>https://raw.github.com/DbUp/DbUp/master/src/Information/dbup-icon.png</PackageIconUrl>
-    <PackageProjectUrl>http://dbup.github.com</PackageProjectUrl>
+    <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.opensource.org/licenses/mit-license.php</PackageLicenseUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/dbup-sqlite/dbup-sqlite.csproj
+++ b/src/dbup-sqlite/dbup-sqlite.csproj
@@ -12,7 +12,7 @@
     <PackageId>dbup-sqlite</PackageId>
     <PackageReleaseNotes>https://github.com/DbUp/DbUp/releases</PackageReleaseNotes>
     <PackageIconUrl>https://raw.github.com/DbUp/DbUp/master/src/Information/dbup-icon.png</PackageIconUrl>
-    <PackageProjectUrl>http://dbup.github.com</PackageProjectUrl>
+    <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.opensource.org/licenses/mit-license.php</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -12,7 +12,7 @@
     <PackageId>dbup-sqlserver</PackageId>
     <PackageReleaseNotes>https://github.com/DbUp/DbUp/releases</PackageReleaseNotes>
     <PackageIconUrl>https://raw.github.com/DbUp/DbUp/master/src/Information/dbup-icon.png</PackageIconUrl>
-    <PackageProjectUrl>http://dbup.github.com</PackageProjectUrl>
+    <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseUrl>http://www.opensource.org/licenses/mit-license.php</PackageLicenseUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>


### PR DESCRIPTION
Looks like the redirects were broken by the deprecation of github.com subdomains in April:

![image](https://user-images.githubusercontent.com/483470/123595640-0cfa1580-d7e9-11eb-8cfb-c191b406b647.png)
