### PR TITLE
[jhw] fix handling of # comments in mysql query parsing

### DIFF
--- a/src/dbup-core/Support/SqlCommandReader.cs
+++ b/src/dbup-core/Support/SqlCommandReader.cs
@@ -35,6 +35,7 @@ namespace DbUp.Support
                         case CharacterType.Command:
                         case CharacterType.SlashStarComment:
                         case CharacterType.DashComment:
+                        case CharacterType.HashTagComment:
                         case CharacterType.BracketedText:
                         case CharacterType.QuotedString:
                         case CharacterType.CustomStatement:

--- a/src/dbup-core/Support/SqlParser.cs
+++ b/src/dbup-core/Support/SqlParser.cs
@@ -17,6 +17,7 @@ namespace DbUp.Support
         const char StarChar = '*';
         const char OpenBracketChar = '[';
         const char CloseBracketChar = ']';
+        const char HashTagChar = '#';
 
         protected const int FailedRead = -1;
 
@@ -77,6 +78,10 @@ namespace DbUp.Support
                 else if (IsBeginningOfDashDashComment)
                 {
                     ReadDashDashComment();
+                }
+                else if (IsBeginningOfHashTagComment)
+                {
+                    ReadHashTagComment();
                 }
                 else if (IsBeginningOfSlashStarComment)
                 {
@@ -271,6 +276,8 @@ namespace DbUp.Support
             }
         }
 
+        bool IsBeginningOfHashTagComment => CurrentChar == HashTagChar;
+
         bool IsBeginningOfSlashStarComment => CurrentChar == SlashChar && Peek() == StarChar;
 
         bool IsBeginningOfDelimiter
@@ -357,6 +364,25 @@ namespace DbUp.Support
                     break;
                 }
                 ReadCharacter(CharacterType.DashComment, CurrentChar);
+            }
+            while (!IsEndOfLine);
+        }
+
+        /// <summary>
+        /// Reads # comments
+        /// </summary>
+        void ReadHashTagComment()
+        {
+            // Writes the current dash.
+            ReadCharacter(CharacterType.HashTagComment, CurrentChar);
+            // Read until we hit the end of line.
+            do
+            {
+                if (Read() == FailedRead)
+                {
+                    break;
+                }
+                ReadCharacter(CharacterType.HashTagComment, CurrentChar);
             }
             while (!IsEndOfLine);
         }
@@ -462,6 +488,8 @@ namespace DbUp.Support
             Delimiter,
             /// <summary>Character is a custom statement (open for new implementation)</summary>
             CustomStatement,
+            /// <summary>Character belongs to a # comment</summary>
+            HashTagComment,
         }
     }
 }

--- a/src/dbup-tests/Support/MySql/MySqlConnectionManagerTests.cs
+++ b/src/dbup-tests/Support/MySql/MySqlConnectionManagerTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -75,7 +75,37 @@ namespace DbUp.Tests.Support.MySql
                 "CREATE TABLE IF NOT EXISTS 'BAR';"
             });
         }
-        
+
+        [Fact]
+        public void ParsesOutCommentWithinStoredProcedureContainingApostrophe()
+        {
+            var createProcedureCommand =
+@"CREATE PROCEDURE Test(
+    IN param1 smallint)
+BEGIN 
+    SELECT
+        field1,
+        field2 # this field isn't very useful
+    FROM
+        table1
+END";
+
+            var multiCommand = new StringBuilder()
+               .AppendLine("DELIMITER $$")
+               .Append(createProcedureCommand)
+               .AppendLine("$$")
+               .AppendLine("DELIMITER ;");
+
+            var connectionManager = new MySqlConnectionManager("connectionstring");
+            var result = connectionManager.SplitScriptIntoCommands(multiCommand.ToString())
+                .ToArray();
+
+            result.ShouldBe(new[]
+            {
+                createProcedureCommand
+            });
+        }
+
         [Fact]
         public void DoesNotGetStuckInSkipWhitespace()
         {


### PR DESCRIPTION
I had an issue trying to create a stored procedure because I had a `# this isn't an important comment` comment in the middle of it, and that broke the parsing of it. I see we handle `--` and `/*` comments, but not `#` comments. 

https://dev.mysql.com/doc/refman/5.6/en/comments.html