### PR TITLE
Add SQLite journal extension

### DIFF
--- a/src/dbup-postgresql/PostgresqlExtensions.cs
+++ b/src/dbup-postgresql/PostgresqlExtensions.cs
@@ -205,7 +205,7 @@ public static class PostgresqlExtensions
     }
 
     /// <summary>
-    /// Tracks the list of executed scripts in a SQL Server table.
+    /// Tracks the list of executed scripts in a PostgreSQL table.
     /// </summary>
     /// <param name="builder">The builder.</param>
     /// <param name="schema">The schema.</param>

--- a/src/dbup-sqlite/SqliteExtensions.cs
+++ b/src/dbup-sqlite/SqliteExtensions.cs
@@ -49,4 +49,15 @@ public static class SQLiteExtensions
         builder.WithPreprocessor(new SQLitePreprocessor());
         return builder;
     }
+    
+    /// <summary>
+    /// Tracks the list of executed scripts in a custom SQLite table.
+    /// </summary>
+    /// <param name="table">The name of the table used to store the list of executed scripts.</param>
+    /// <returns>The <see cref="UpgradeEngineBuilder"/> used to set the journal table name.</returns>
+    public static UpgradeEngineBuilder JournalToSQLiteTable(this UpgradeEngineBuilder builder, string table)
+    {
+        builder.Configure(c => c.Journal = new SQLiteTableJournal(() => c.ConnectionManager, () => c.Log, table));
+        return builder;
+    }
 }

--- a/src/dbup-tests/Support/SQLite/ApprovalFiles/NoPublicApiChanges.Run.DotNet.verified.cs
+++ b/src/dbup-tests/Support/SQLite/ApprovalFiles/NoPublicApiChanges.Run.DotNet.verified.cs
@@ -4,6 +4,7 @@
 
 public static class SQLiteExtensions
 {
+    public static DbUp.Builder.UpgradeEngineBuilder JournalToSQLiteTable(this DbUp.Builder.UpgradeEngineBuilder builder, string table) { }
     public static DbUp.Builder.UpgradeEngineBuilder SQLiteDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SQLiteDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.SQLite.Helpers.SharedConnection sharedConnection) { }
 }

--- a/src/dbup-tests/Support/SQLite/ApprovalFiles/NoPublicApiChanges.Run.Net.verified.cs
+++ b/src/dbup-tests/Support/SQLite/ApprovalFiles/NoPublicApiChanges.Run.Net.verified.cs
@@ -4,6 +4,7 @@
 
 public static class SQLiteExtensions
 {
+    public static DbUp.Builder.UpgradeEngineBuilder JournalToSQLiteTable(this DbUp.Builder.UpgradeEngineBuilder builder, string table) { }
     public static DbUp.Builder.UpgradeEngineBuilder SQLiteDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SQLiteDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.SQLite.Helpers.SharedConnection sharedConnection) { }
 }

--- a/src/dbup-tests/Support/SQLite/ApprovalFiles/dbup-sqlite.approved.cs
+++ b/src/dbup-tests/Support/SQLite/ApprovalFiles/dbup-sqlite.approved.cs
@@ -4,6 +4,7 @@
 
 public static class SQLiteExtensions
 {
+    public static DbUp.Builder.UpgradeEngineBuilder JournalToSQLiteTable(this DbUp.Builder.UpgradeEngineBuilder builder, string table) { }
     public static DbUp.Builder.UpgradeEngineBuilder SQLiteDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SQLiteDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.SQLite.Helpers.SharedConnection sharedConnection) { }
 }


### PR DESCRIPTION
(copied from #563)

This PR adds an extension/helper method so SQLite databases can use the same fluid builder syntax as SQL Server, PostgreSQL, and Redshift.

It also fixes the comment from the PostgreSQL version, which I'm assuming was copied and pasted from SQL Server (as I did for the SQLite one :sweat_smile:)

I noticed the existing methods had no test coverage, so lmk if you'd like that added!