### PR TITLE
Upgrade Npgsql to support SCRAM authentication - default since v10+

### DIFF
--- a/src/dbup-postgresql/dbup-postgresql.csproj
+++ b/src/dbup-postgresql/dbup-postgresql.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net35'">
-    <PackageReference Include="Npgsql" Version="3.2.6" />
+    <PackageReference Include="Npgsql" Version="3.2.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
DbUp/dbup-postgresql includes Npgsql v3.2.**6** and SCRAM authentication is supported in Npgsql v3.2.**7**+. Specifically SCRAM-SHA-256, as detailed in error messages or alternatively "Authentication method not supported (Received: 10)" is fixed by using Npgsql v3.2.7 or later - this hopefully fixes and closes #545 and #599 

There are lots of later versions of Npgsql to choose from v4.x; v5.x; and v6.x but I've chosen the minor upgrade from v3.2.6→v3.2.7 as I've verified that this works - just in case someone still requires .NET Standard v1.3.