### PR TITLE
Don't give out password length in logs

### DIFF
--- a/src/dbup-postgresql/PostgresqlExtensions.cs
+++ b/src/dbup-postgresql/PostgresqlExtensions.cs
@@ -150,7 +150,7 @@ public static class PostgresqlExtensions
         var logMasterConnectionStringBuilder = new NpgsqlConnectionStringBuilder(masterConnectionStringBuilder.ConnectionString);
         if (!string.IsNullOrEmpty(logMasterConnectionStringBuilder.Password))
         {
-            logMasterConnectionStringBuilder.Password = string.Empty.PadRight(masterConnectionStringBuilder.Password.Length, '*');
+            logMasterConnectionStringBuilder.Password = "******";
         }
 
         logger.WriteInformation("Master ConnectionString => {0}", logMasterConnectionStringBuilder.ConnectionString);

--- a/src/dbup-redshift/RedshiftExtensions.cs
+++ b/src/dbup-redshift/RedshiftExtensions.cs
@@ -119,7 +119,7 @@ public static class RedshiftExtensions
         var logMasterConnectionStringBuilder = new NpgsqlConnectionStringBuilder(masterConnectionStringBuilder.ConnectionString);
         if (!string.IsNullOrEmpty(logMasterConnectionStringBuilder.Password))
         {
-            logMasterConnectionStringBuilder.Password = string.Empty.PadRight(masterConnectionStringBuilder.Password.Length, '*');
+            logMasterConnectionStringBuilder.Password = "******";
         }
 
         logger.WriteInformation("Master ConnectionString => {0}", logMasterConnectionStringBuilder.ConnectionString);

--- a/src/dbup-sqlserver/SqlServerExtensions.cs
+++ b/src/dbup-sqlserver/SqlServerExtensions.cs
@@ -362,7 +362,7 @@ public static class SqlServerExtensions
         masterConnectionStringBuilder.InitialCatalog = "master";
         var logMasterConnectionStringBuilder = new SqlConnectionStringBuilder(masterConnectionStringBuilder.ConnectionString)
         {
-            Password = string.Empty.PadRight(masterConnectionStringBuilder.Password.Length, '*')
+            Password = "******"
         };
 
         logger.WriteInformation("Master ConnectionString => {0}", logMasterConnectionStringBuilder.ConnectionString);


### PR DESCRIPTION
Password length is definitely not the most sensitive piece of information, but it's still better to avoid logging it.