### PR TITLE
EnsureDatabase.For: Fixed issue when postres database name is always 'postgres'

### DIFF
--- a/src/dbup-postgresql/PostgresqlExtensions.cs
+++ b/src/dbup-postgresql/PostgresqlExtensions.cs
@@ -145,8 +145,6 @@ public static class PostgresqlExtensions
             throw new InvalidOperationException("The connection string does not specify a database name.");
         }
 
-        masterConnectionStringBuilder.Database = "postgres";
-
         var logMasterConnectionStringBuilder = new NpgsqlConnectionStringBuilder(masterConnectionStringBuilder.ConnectionString);
         if (!string.IsNullOrEmpty(logMasterConnectionStringBuilder.Password))
         {


### PR DESCRIPTION
In dbup-postgres value with `Database` key  from connection string is always ignored and replaced by `postgres`, so it isn't possible to set database name via connection string. 