### PR TITLE
Revert some changed made in #559 to maintain binary compatibility

### DIFF
--- a/src/dbup-sqlserver/AzureSqlServerExtensions.cs
+++ b/src/dbup-sqlserver/AzureSqlServerExtensions.cs
@@ -10,23 +10,6 @@ using DbUp.SqlServer;
 // ReSharper disable CheckNamespace
 public static class AzureSqlServerExtensions
 {
-    /// <summary>Creates an upgrader for SQL Server databases.</summary>
-    /// <param name="supported">Fluent helper type.</param>
-    /// <param name="connectionString">The connection string.</param>
-    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
-    /// <param name="useAzureSqlIntegratedSecurity">Whether to use Azure SQL Integrated Security</param>
-    /// <returns>A builder for a database upgrader designed for SQL Server databases.</returns>
-    [Obsolete("Use \"AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases, string, string)\" if passing \"true\" to \"useAzureSqlIntegratedSecurity\".")]
-    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity)
-    {
-        if (useAzureSqlIntegratedSecurity)
-        {
-            return AzureSqlDatabaseWithIntegratedSecurity(supported, connectionString, schema);
-        }
-
-        return supported.SqlDatabase(new SqlConnectionManager(connectionString), schema);
-    }
-
     /// <summary>Creates an upgrader for Azure SQL Databases using Azure AD Integrated Security.</summary>
     /// <param name="supported">Fluent helper type.</param>
     /// <param name="connectionString">The connection string.</param>

--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -1,7 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data.SqlClient;
 using DbUp.Engine.Transactions;
 using DbUp.Support;
+#if SUPPORTS_AZURE_AD
+using Microsoft.Azure.Services.AppAuthentication;
+#endif
 
 namespace DbUp.SqlServer
 {
@@ -25,6 +29,30 @@ namespace DbUp.SqlServer
                  return conn;
              }))
         { }
+
+#if SUPPORTS_AZURE_AD
+        /// <summary>
+        /// Manages Sql Database Connections
+        /// </summary>
+        /// <param name="connectionString"></param>
+        /// <param name="useAzureSqlIntegratedSecurity">Whether to use Azure SQL Integrated Sercurity</param>
+        [Obsolete("Use the \"AzureSqlDatabaseWithIntegratedSecurity\" extension method instead")]
+        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity)
+            : base(new DelegateConnectionFactory((log, dbManager) =>
+            {
+                var conn = new SqlConnection(connectionString);
+
+                if (useAzureSqlIntegratedSecurity)
+                    conn.AccessToken = new AzureServiceTokenProvider().GetAccessTokenAsync("https://database.windows.net/").ConfigureAwait(false).GetAwaiter().GetResult();
+
+                if (dbManager.IsScriptOutputLogged)
+                    conn.InfoMessage += (sender, e) => log.WriteInformation($"{{0}}", e.Message);
+
+                return conn;
+            }))
+        {
+        }
+#endif
 
         public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
         {

--- a/src/dbup-sqlserver/SqlServerExtensions.cs
+++ b/src/dbup-sqlserver/SqlServerExtensions.cs
@@ -43,6 +43,25 @@ public static class SqlServerExtensions
         return SqlDatabase(new SqlConnectionManager(connectionString), schema);
     }
 
+#if SUPPORTS_AZURE_AD
+    /// <summary>Creates an upgrader for SQL Server databases.</summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo' if <see langword="null" />.</param>
+    /// <param name="useAzureSqlIntegratedSecurity">Whether to use Azure SQL Integrated Security</param>
+    /// <returns>A builder for a database upgrader designed for SQL Server databases.</returns>
+    [Obsolete("Use \"AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases, string, string)\" if passing \"true\" to \"useAzureSqlIntegratedSecurity\".")]
+    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity)
+    {
+        if (useAzureSqlIntegratedSecurity)
+        {
+            return supported.AzureSqlDatabaseWithIntegratedSecurity(connectionString, schema);
+        }
+
+        return supported.SqlDatabase(new SqlConnectionManager(connectionString), schema);
+    }
+#endif
+
     /// <summary>
     /// Creates an upgrader for SQL Server databases.
     /// </summary>
@@ -229,7 +248,7 @@ public static class SqlServerExtensions
             }
             catch (SqlException)
             {
-                // Failed to connect to master, lets try direct  
+                // Failed to connect to master, lets try direct
                 if (DatabaseExistsIfConnectedToDirectly(logger, connectionString, databaseName))
                     return;
 

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
@@ -6,8 +6,6 @@ public static class AzureSqlServerExtensions
     public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string resource) { }
     public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string resource, string tenantId, string azureAdInstance = "https://login.microsoftonline.com/") { }
-    [System.ObsoleteAttribute("Use "AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases, string, string)" if passing "true" to "useAzureSqlIntegratedSecurity".")]
-    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity) { }
 }
 public static class SqlServerExtensions
 {
@@ -15,6 +13,8 @@ public static class SqlServerExtensions
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema = null) { }
+    [System.ObsoleteAttribute("Use "AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases, string, string)" if passing "true" to "useAzureSqlIntegratedSecurity".")]
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForDropDatabase supported, string connectionString) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.SqlServer.AzureDatabaseEdition azureDatabaseEdition) { }
@@ -47,6 +47,8 @@ namespace DbUp.SqlServer
     public class SqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
         public SqlConnectionManager(string connectionString) { }
+        [System.ObsoleteAttribute("Use the "AzureSqlDatabaseWithIntegratedSecurity" extension method instead")]
+        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class SqlScriptExecutor : DbUp.Support.ScriptExecutor, DbUp.Engine.IScriptExecutor

--- a/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
@@ -6,8 +6,6 @@ public static class AzureSqlServerExtensions
     public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string resource) { }
     public static DbUp.Builder.UpgradeEngineBuilder AzureSqlDatabaseWithIntegratedSecurity(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string resource, string tenantId, string azureAdInstance = "https://login.microsoftonline.com/") { }
-    [System.ObsoleteAttribute("Use "AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases, string, string)" if passing "true" to "useAzureSqlIntegratedSecurity".")]
-    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity) { }
 }
 public static class SqlServerExtensions
 {
@@ -16,6 +14,8 @@ public static class SqlServerExtensions
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema = null) { }
+    [System.ObsoleteAttribute("Use "AzureSqlDatabaseWithIntegratedSecurity(this SupportedDatabases, string, string)" if passing "true" to "useAzureSqlIntegratedSecurity".")]
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, bool useAzureSqlIntegratedSecurity) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForDropDatabase supported, string connectionString) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.SqlServer.AzureDatabaseEdition azureDatabaseEdition) { }
@@ -48,6 +48,8 @@ namespace DbUp.SqlServer
     public class SqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
         public SqlConnectionManager(string connectionString) { }
+        [System.ObsoleteAttribute("Use the "AzureSqlDatabaseWithIntegratedSecurity" extension method instead")]
+        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class SqlScriptExecutor : DbUp.Support.ScriptExecutor, DbUp.Engine.IScriptExecutor


### PR DESCRIPTION
The following two APIs were removed:
1. https://github.com/DbUp/DbUp/pull/559/files#diff-57c0a543eea2d12709e1fa053c8c5aff51a96be7e0e6e377254fccafd6b006fbL9
2. https://github.com/DbUp/DbUp/pull/559/files#diff-57c0a543eea2d12709e1fa053c8c5aff51a96be7e0e6e377254fccafd6b006fbL36

The first one is compile-compatible, but may still cause a problem if a newer DLL was used against something that was compiled against an older (which is unlikely though).

However the second one breaks compile compatibility.

This unblocks #612 