### PR TITLE
Switch to Mainline versioning

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,1 @@
+mode: Mainline

--- a/build.cake
+++ b/build.cake
@@ -33,7 +33,7 @@ Task("Restore")
     .IsDependentOn("Version")
     .Does(() => {
         DotNetCoreRestore("src", new DotNetCoreRestoreSettings() {
-            ArgumentCustomization = args => args.Append("/p:Version=" + versionInfo.NuGetVersion)
+            ArgumentCustomization = args => args.Append("/p:Version=" + versionInfo.SemVer)
         });
     });
 
@@ -44,7 +44,7 @@ Task("Build")
     .Does(() => {
         var settings =  new MSBuildSettings()
             .SetConfiguration("Release")
-            .WithProperty("Version", versionInfo.NuGetVersion)
+            .WithProperty("Version", versionInfo.SemVer)
             .WithProperty("PackageOutputPath", System.IO.Path.GetFullPath(outputDir))
             .WithTarget("Build")
             .WithTarget("Pack");
@@ -70,7 +70,7 @@ Task("Package")
 
         NuGetPack("./src/dbup/dbup.nuspec", new NuGetPackSettings() {
             OutputDirectory = System.IO.Path.GetFullPath(outputDir),
-            Version = versionInfo.NuGetVersion
+            Version = versionInfo.SemVer
         });
     });
 


### PR DESCRIPTION
The project currently uses [Continuous Delivery](https://gitversion.net/docs/reference/modes/continuous-delivery) versioning. This results in the builds of each branch only differing by the version metadata. 

The problems with this approach:
- We must manually tag `master` builds (and rebuild them) before shipping, precluding us from shipping automatically on merge
- NuGet does not make a (great) distinction based on Metadata, particularly in the filename
- We can't push every build to GitHub Packages for use/testing

This PR changes the project to use [Mainline](https://gitversion.net/docs/reference/modes/mainline) versioning. This means that every commit gets a unique and predictable version (barring rebases/squash).

It also switches the version tagging to use SemVer instead of NuGet scheme. This should only make a difference on branch builds and maintain current behaviour for `master`.