### PR TITLE
Replaced artifacts with a push to GitHub Packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,11 +34,9 @@ jobs:
           OCTOVERSION_CurrentBranch: ${{ github.ref }}
           AssentNonInteractive: true
 
-      - name: Upload NuGet packages as artifacts ⬆️
-        uses: actions/upload-artifact@v3
-        with:
-          name: nuget-packages
-          path: artifacts/*.nupkg
+      - name: Push NuGet packages to GitHub Packages ⬆️
+        working-directory: artifacts
+        run: dotnet nuget push *.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/DbUp/index.json"
 
       - name: Test Report 🧪
         uses: dorny/test-reporter@v1

--- a/src/dbup-core/dbup-core.csproj
+++ b/src/dbup-core/dbup-core.csproj
@@ -15,7 +15,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/src/dbup-core/dbup-core.csproj
+++ b/src/dbup-core/dbup-core.csproj
@@ -15,6 +15,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/src/dbup-firebird/dbup-firebird.csproj
+++ b/src/dbup-firebird/dbup-firebird.csproj
@@ -14,6 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/src/dbup-firebird/dbup-firebird.csproj
+++ b/src/dbup-firebird/dbup-firebird.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/src/dbup-mysql/dbup-mysql.csproj
+++ b/src/dbup-mysql/dbup-mysql.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/src/dbup-mysql/dbup-mysql.csproj
+++ b/src/dbup-mysql/dbup-mysql.csproj
@@ -14,6 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
@@ -23,7 +24,7 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' OR '$(TargetFramework)' == 'net45' ">
     <DefineConstants>$(DefineConstants);MY_SQL_DATA_6_9_5</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
   </ItemGroup>
@@ -41,5 +42,5 @@
     <None Visible="false" Include="../../dbup-icon.png" Pack="True" PackagePath="" />
   </ItemGroup>
 
-  
+
 </Project>

--- a/src/dbup-oracle/dbup-oracle.csproj
+++ b/src/dbup-oracle/dbup-oracle.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dbup-oracle/dbup-oracle.csproj
+++ b/src/dbup-oracle/dbup-oracle.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
-    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dbup-postgresql/dbup-postgresql.csproj
+++ b/src/dbup-postgresql/dbup-postgresql.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/dbup-postgresql/dbup-postgresql.csproj
+++ b/src/dbup-postgresql/dbup-postgresql.csproj
@@ -14,6 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -23,7 +24,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">
     <DefineConstants>$(DefineConstants);NPGSQLv2</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
   </ItemGroup>

--- a/src/dbup-redshift/dbup-redshift.csproj
+++ b/src/dbup-redshift/dbup-redshift.csproj
@@ -14,6 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -23,7 +24,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">
     <DefineConstants>$(DefineConstants);NPGSQLv2</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
   </ItemGroup>
@@ -39,5 +40,5 @@
   <ItemGroup>
     <None Visible="false" Include="../../dbup-icon.png" Pack="True" PackagePath="" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/dbup-redshift/dbup-redshift.csproj
+++ b/src/dbup-redshift/dbup-redshift.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/dbup-sqlanywhere/dbup-sqlanywhere.csproj
+++ b/src/dbup-sqlanywhere/dbup-sqlanywhere.csproj
@@ -7,7 +7,7 @@
     <Company>Dillistone Systems</Company>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/dbup-sqlanywhere/dbup-sqlanywhere.csproj
+++ b/src/dbup-sqlanywhere/dbup-sqlanywhere.csproj
@@ -7,6 +7,7 @@
     <Company>Dillistone Systems</Company>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/dbup-sqlce/dbup-sqlce.csproj
+++ b/src/dbup-sqlce/dbup-sqlce.csproj
@@ -14,6 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/src/dbup-sqlce/dbup-sqlce.csproj
+++ b/src/dbup-sqlce/dbup-sqlce.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/src/dbup-sqlite-mono/dbup-sqlite-mono.csproj
+++ b/src/dbup-sqlite-mono/dbup-sqlite-mono.csproj
@@ -14,6 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/src/dbup-sqlite-mono/dbup-sqlite-mono.csproj
+++ b/src/dbup-sqlite-mono/dbup-sqlite-mono.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/src/dbup-sqlite/dbup-sqlite.csproj
+++ b/src/dbup-sqlite/dbup-sqlite.csproj
@@ -14,6 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/dbup-sqlite/dbup-sqlite.csproj
+++ b/src/dbup-sqlite/dbup-sqlite.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -14,6 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>dbup-icon.png</PackageIcon>
     <PackageProjectUrl>https://dbup.github.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/DbUp/DbUp</RepositoryUrl>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/src/dbup/dbup.nuspec
+++ b/src/dbup/dbup.nuspec
@@ -9,7 +9,7 @@
     reference the SQL Server code. Uninstall this package and install dbup-sqlserver, or the package for the server(s) you are targeting instead!</description>
     <language>en-US</language>
     <license type="expression">MIT</license>
-    <repository>https://github.com/DbUp/DbUp</repository>
+    <repository url="https://github.com/DbUp/DbUp" />
     <releaseNotes>https://github.com/DbUp/DbUp/releases</releaseNotes>
     <projectUrl>http://dbup.github.com</projectUrl>
     <icon>dbup-icon.png</icon>

--- a/src/dbup/dbup.nuspec
+++ b/src/dbup/dbup.nuspec
@@ -9,6 +9,7 @@
     reference the SQL Server code. Uninstall this package and install dbup-sqlserver, or the package for the server(s) you are targeting instead!</description>
     <language>en-US</language>
     <license type="expression">MIT</license>
+    <repositoryUrl>https://github.com/DbUp/DbUp</repositoryUrl>
     <releaseNotes>https://github.com/DbUp/DbUp/releases</releaseNotes>
     <projectUrl>http://dbup.github.com</projectUrl>
     <icon>dbup-icon.png</icon>

--- a/src/dbup/dbup.nuspec
+++ b/src/dbup/dbup.nuspec
@@ -9,7 +9,7 @@
     reference the SQL Server code. Uninstall this package and install dbup-sqlserver, or the package for the server(s) you are targeting instead!</description>
     <language>en-US</language>
     <license type="expression">MIT</license>
-    <repository url="https://github.com/DbUp/DbUp" />
+    <repository type="git" url="https://github.com/DbUp/DbUp.git" />
     <releaseNotes>https://github.com/DbUp/DbUp/releases</releaseNotes>
     <projectUrl>http://dbup.github.com</projectUrl>
     <icon>dbup-icon.png</icon>

--- a/src/dbup/dbup.nuspec
+++ b/src/dbup/dbup.nuspec
@@ -9,7 +9,7 @@
     reference the SQL Server code. Uninstall this package and install dbup-sqlserver, or the package for the server(s) you are targeting instead!</description>
     <language>en-US</language>
     <license type="expression">MIT</license>
-    <repositoryUrl>https://github.com/DbUp/DbUp</repositoryUrl>
+    <repository>https://github.com/DbUp/DbUp</repository>
     <releaseNotes>https://github.com/DbUp/DbUp/releases</releaseNotes>
     <projectUrl>http://dbup.github.com</projectUrl>
     <icon>dbup-icon.png</icon>


### PR DESCRIPTION
I can't see a reason why we wouldn't push all packages to GH Packages

Depends on #621