### PR TITLE
Revert "EnsureDatabase.For: Fixed issue when postres database name is always 'postgres'"

### DIFF
--- a/src/dbup-postgresql/PostgresqlExtensions.cs
+++ b/src/dbup-postgresql/PostgresqlExtensions.cs
@@ -145,6 +145,8 @@ public static class PostgresqlExtensions
             throw new InvalidOperationException("The connection string does not specify a database name.");
         }
 
+        masterConnectionStringBuilder.Database = "postgres";
+
         var logMasterConnectionStringBuilder = new NpgsqlConnectionStringBuilder(masterConnectionStringBuilder.ConnectionString);
         if (!string.IsNullOrEmpty(logMasterConnectionStringBuilder.Password))
         {


### PR DESCRIPTION
Reverts #605
Supersedes #620
Resolves #619