### PR TITLE
Polish Build and Release Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,11 +13,6 @@ jobs:
         with:
           fetch-depth: 0 # all
 
-      - name: Setup .NET 2.0
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 2.0.x
-
       - name: Setup .NET 6.0
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,7 @@ jobs:
             PACKAGE_KEY: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Create Draft Release'
-        #if: ${{ format('{0}', github.ref_name) == 'master' }}
-        # Use the following condition for a single test build only
-        if: ${{ format('{0}', github.ref_name) == 'polish-build-and-release-pipelines' && format('{0}', env.GITHUB_TOKEN) != '' }}
+        if: ${{ format('{0}', github.ref_name) == 'master' && format('{0}', env.GITHUB_TOKEN) != '' }}
         shell: pwsh
         working-directory: artifacts
         # Can't just use wildcard in this command due to https://github.com/cli/cli/issues/5099 so use Get-Item

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true # Avoid pre-populating the NuGet package cache
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,10 @@ jobs:
         env:
             PACKAGE_KEY: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 'List Directory Contents'
+        shell: pwsh
+        run: dir
+
       - name: 'Create Draft Release'
         #if: ${{ format('{0}', github.ref_name) == 'master' }}
         # Use the following condition for a single test build only

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ format('{0}', github.ref_name) == 'polish-build-and-release-pipelines' && format('{0}', env.GITHUB_TOKEN) != '' }}
         shell: pwsh
         # Can't just use wildcard in this command due to https://github.com/cli/cli/issues/5099 so use Get-Item
-        run: gh release create --draft --title "${{ steps.cake-build.outputs.BUILDVERSION }}" "${{ steps.build-solution.outputs.BUILDVERSION }}" (Get-Item *.nupkg)
+        run: gh release create --draft --title "${{ steps.cake-build.outputs.BUILDVERSION }}" "${{ steps.cake-build.outputs.BUILDVERSION }}" (Get-Item *.nupkg)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,11 @@ jobs:
           AssentNonInteractive: true
 
       - name: Push NuGet packages to GitHub Packages ⬆️
+        if: ${{ format('{0}', env.PACKAGE_KEY) != '' }}
         working-directory: artifacts
-        run: dotnet nuget push *.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/DbUp/index.json"
+        run: dotnet nuget push *.nupkg --api-key ${{ env.PACKAGE_KEY }} --source "https://nuget.pkg.github.com/DbUp/index.json"
+        env:
+            PACKAGE_KEY: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test Report 🧪
         uses: dorny/test-reporter@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
         run: ./install-sql-ce.ps1
 
       - name: Cake Build 🏗️
+        id: cake-build
         shell: powershell
         run: ./build.ps1
         env:
@@ -40,6 +41,16 @@ jobs:
         run: dotnet nuget push *.nupkg --api-key ${{ env.PACKAGE_KEY }} --source "https://nuget.pkg.github.com/DbUp/index.json"
         env:
             PACKAGE_KEY: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Create Draft Release'
+        #if: ${{ format('{0}', github.ref_name) == 'master' }}
+        # Use the following condition for a single test build only
+        if: ${{ format('{0}', github.ref_name) == 'polish-build-and-release-pipelines' && format('{0}', env.GITHUB_TOKEN) != '' }}
+        shell: pwsh
+        # Can't just use wildcard in this command due to https://github.com/cli/cli/issues/5099 so use Get-Item
+        run: gh release create --draft --title "${{ steps.cake-build.outputs.BUILDVERSION }}" "${{ steps.build-solution.outputs.BUILDVERSION }}" (Get-Item *.nupkg)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test Report 🧪
         uses: dorny/test-reporter@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,15 +42,12 @@ jobs:
         env:
             PACKAGE_KEY: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'List Directory Contents'
-        shell: pwsh
-        run: dir
-
       - name: 'Create Draft Release'
         #if: ${{ format('{0}', github.ref_name) == 'master' }}
         # Use the following condition for a single test build only
         if: ${{ format('{0}', github.ref_name) == 'polish-build-and-release-pipelines' && format('{0}', env.GITHUB_TOKEN) != '' }}
         shell: pwsh
+        working-directory: artifacts
         # Can't just use wildcard in this command due to https://github.com/cli/cli/issues/5099 so use Get-Item
         run: gh release create --draft --title "${{ steps.cake-build.outputs.Version_Info_SemVer }}" "${{ steps.cake-build.outputs.Version_Info_SemVer }}" (Get-Item *.nupkg)
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ format('{0}', github.ref_name) == 'polish-build-and-release-pipelines' && format('{0}', env.GITHUB_TOKEN) != '' }}
         shell: pwsh
         # Can't just use wildcard in this command due to https://github.com/cli/cli/issues/5099 so use Get-Item
-        run: gh release create --draft --title "${{ steps.cake-build.outputs.BUILDVERSION }}" "${{ steps.cake-build.outputs.BUILDVERSION }}" (Get-Item *.nupkg)
+        run: gh release create --draft --title "${{ steps.cake-build.outputs.Version_Info_SemVer }}" "${{ steps.cake-build.outputs.Version_Info_SemVer }}" (Get-Item *.nupkg)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,34 @@
+name: Publish DbUp Packages to NuGet
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: 'Publish Package'
+    runs-on: windows-latest
+
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true # Avoid pre-populating the NuGet package cache
+
+    steps:
+
+    - name: 'Check Tag Value'
+      run: echo ${{ github.event.release.tag_name }}
+
+    - uses: robinraju/release-downloader@v1.3
+      name: 'Download Package from Release'
+      with:
+        repository: 'DbUp/DbUp'
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: '${{ github.event.release.tag_name }}'
+        fileName: '*'
+        tarBall: false
+        zipBall: false
+
+    - name: 'Upload to NuGet'
+      shell: pwsh
+      run: dotnet nuget push *.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate --api-key ${{ secrets.NUGET_APIKEY }}

--- a/build.cake
+++ b/build.cake
@@ -28,6 +28,7 @@ Task("Version")
         versionInfo = GitVersion(new GitVersionSettings{ OutputType = GitVersionOutput.Json });
 
         Information(SerializeJsonPretty(versionInfo));
+        Information("::set-output name=BUILDVERSION::" + versionInfo.SemVer);
     });
 
 Task("Restore")

--- a/build.cake
+++ b/build.cake
@@ -28,7 +28,7 @@ Task("Version")
         versionInfo = GitVersion(new GitVersionSettings{ OutputType = GitVersionOutput.Json });
 
         Information(SerializeJsonPretty(versionInfo));
-        System.IO.File.WriteAllText(System.Environment.GetEnvironmentVariable("GITHUB_ENV"), "BUILDVERSION=" + versionInfo.SemVer)
+        System.IO.File.WriteAllText(System.Environment.GetEnvironmentVariable("GITHUB_ENV"), "BUILDVERSION=" + versionInfo.SemVer);
     });
 
 Task("Restore")

--- a/build.cake
+++ b/build.cake
@@ -33,7 +33,7 @@ Task("Version")
 Task("Restore")
     .IsDependentOn("Version")
     .Does(() => {
-        DotNetCoreRestore("src", new DotNetCoreRestoreSettings() {
+        DotNetRestore("src", new DotNetRestoreSettings() {
             ArgumentCustomization = args => args.Append("/p:Version=" + versionInfo.SemVer)
         });
     });
@@ -56,7 +56,7 @@ Task("Build")
 Task("Test")
     .IsDependentOn("Build")
     .Does(() => {
-         DotNetCoreTest("./src/dbup-tests/dbup-tests.csproj", new DotNetCoreTestSettings
+         DotNetTest("./src/dbup-tests/dbup-tests.csproj", new DotNetTestSettings
         {
             Configuration = "Release",
             NoBuild = true,

--- a/build.cake
+++ b/build.cake
@@ -28,7 +28,8 @@ Task("Version")
         versionInfo = GitVersion(new GitVersionSettings{ OutputType = GitVersionOutput.Json });
 
         Information(SerializeJsonPretty(versionInfo));
-        System.IO.File.WriteAllText(System.Environment.GetEnvironmentVariable("GITHUB_ENV"), "BUILDVERSION=" + versionInfo.SemVer);
+        Information(System.Environment.GetEnvironmentVariable("GITHUB_OUTPUT"));
+        System.IO.File.WriteAllText(System.Environment.GetEnvironmentVariable("GITHUB_OUTPUT"), "Version_Info_SemVer=" + versionInfo.SemVer, Encoding.UTF8);
     });
 
 Task("Restore")

--- a/build.cake
+++ b/build.cake
@@ -28,7 +28,7 @@ Task("Version")
         versionInfo = GitVersion(new GitVersionSettings{ OutputType = GitVersionOutput.Json });
 
         Information(SerializeJsonPretty(versionInfo));
-        Information("::set-output name=BUILDVERSION::" + versionInfo.SemVer);
+        System.IO.File.WriteAllText(System.Environment.GetEnvironmentVariable("GITHUB_ENV"), "BUILDVERSION=" + versionInfo.SemVer)
     });
 
 Task("Restore")

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,5 @@
 ﻿#tool "nuget:?package=GitVersion.CommandLine&Version=5.10.1"
+#addin "nuget:?package=Cake.Json&version=7.0.1"
 
 var target = Argument("target", "Default");
 var outputDir = "./artifacts/";
@@ -17,8 +18,6 @@ Task("Clean")
         }
     });
 
-
-
 GitVersion versionInfo = null;
 Task("Version")
     .Does(() => {
@@ -27,6 +26,8 @@ Task("Version")
             OutputType = GitVersionOutput.BuildServer
         });
         versionInfo = GitVersion(new GitVersionSettings{ OutputType = GitVersionOutput.Json });
+
+        Information(SerializeJsonPretty(versionInfo));
     });
 
 Task("Restore")

--- a/src/DbUp.sln
+++ b/src/DbUp.sln
@@ -5,6 +5,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{FA530374-E28B-419B-BCA2-82A0512774F2}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		dbup\dbup.nuspec = dbup\dbup.nuspec
 		Directory.Build.props = Directory.Build.props
 		..\GitVersion.yml = ..\GitVersion.yml
 		..\README.md = ..\README.md
@@ -45,6 +46,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{7BA5C1AE
 		..\build.cake = ..\build.cake
 		..\build.ps1 = ..\build.ps1
 		..\.github\workflows\main.yml = ..\.github\workflows\main.yml
+		..\.github\workflows\publish-release.yml = ..\.github\workflows\publish-release.yml
 	EndProjectSection
 EndProject
 Global

--- a/src/dbup-tests/ApiTests.cs
+++ b/src/dbup-tests/ApiTests.cs
@@ -34,7 +34,11 @@ namespace DbUp.Tests
             var assembly = type.Assembly;
             var result = GetPublicApi(assembly);
 
-            var framework = RuntimeInformation.FrameworkDescription.Contains(".NET Core") ? "netcore" : "netfx";
+#if NETFRAMEWORK
+            const string framework = "netfx";
+#else
+            const string framework = "netcore"; // "Core" is no longer a thing but maintain the identifier for compatibility.
+#endif
             var approvalPostfix = differByFramework ? $".{framework}" : "";
 
             var config = new Configuration()

--- a/src/dbup-tests/Helpers/FilterFactoryTests.cs
+++ b/src/dbup-tests/Helpers/FilterFactoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Shouldly;
 using Xunit;
@@ -7,44 +8,68 @@ namespace DbUp.Tests.Helpers
 {
     public class FilterFactoryTests
     {
-        [Fact(Skip = "Need to come up with a better way than current directory")]
+        [Fact]
         public void Should_Exclude_ScriptNames_Listed_In_File()
         {
-            var currentDir = System.IO.Directory.GetCurrentDirectory();
-            var excludeFile = System.IO.Path.Combine(currentDir, "TestFilterFiles", "ScriptNames.txt");
-            var filter = Filters.ExcludeScriptNamesInFile(excludeFile);
+            var tempExcludeFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(tempExcludeFile, @"Script20110301_1_Test1.txt
+Script20130525_1_Test5.txt");
 
-            var testScripts = new List<string>
+                var filter = Filters.ExcludeScriptNamesInFile(tempExcludeFile);
+
+                var testScripts = new List<string>
             {
                 "Script20110301_1_Test1.txt",
                 "ShouldRemain.txt",
                 "Script20130525_1_Test5.txt"
             };
 
-            var scriptsToRun = testScripts.Where(filter);
+                var scriptsToRun = testScripts.Where(filter);
 
-            scriptsToRun.ShouldBe(new[] { "ShouldRemain.txt" });
+                scriptsToRun.ShouldBe(new[] { "ShouldRemain.txt" });
+            }
+            finally
+            {
+                if (File.Exists(tempExcludeFile))
+                {
+                    File.Delete(tempExcludeFile);
+                }
+            }
         }
 
-        [Fact(Skip = "Need to come up with a better way than current directory")]
+        [Fact]
         public void Should_Include_Only_ScriptNames_Listed_In_File()
         {
-            var currentDir = System.IO.Directory.GetCurrentDirectory();
-            var excludeFile = System.IO.Path.Combine(currentDir, "TestFilterFiles", "ScriptNames.txt");
-            var filter = Filters.OnlyIncludeScriptNamesInFile(excludeFile);
+            var tempIncludeFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(tempIncludeFile, @"Script20110301_1_Test1.txt
+Script20130525_1_Test5.txt");
 
-            var testScripts = new List<string>
+                var filter = Filters.OnlyIncludeScriptNamesInFile(tempIncludeFile);
+
+                var testScripts = new List<string>
             {
                 "Script20110301_1_Test1.txt",
                 "ShouldNotRemain.txt",
                 "Script20130525_1_Test5.txt"
             };
 
-            var scriptsToRun = testScripts.Where(filter);
+                var scriptsToRun = testScripts.Where(filter);
 
-            scriptsToRun.ShouldNotBeNull();
-            scriptsToRun.Count().ShouldBe(2);
-            scriptsToRun.ShouldNotContain("ShouldNotRemain.txt");
+                scriptsToRun.ShouldNotBeNull();
+                scriptsToRun.Count().ShouldBe(2);
+                scriptsToRun.ShouldNotContain("ShouldNotRemain.txt");
+            }
+            finally
+            {
+                if (File.Exists(tempIncludeFile))
+                {
+                    File.Delete(tempIncludeFile);
+                }
+            }
         }
 
         [Fact]

--- a/src/dbup-tests/dbup-tests.csproj
+++ b/src/dbup-tests/dbup-tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <AssemblyName>dbup-tests</AssemblyName>
     <PackageId>dbup-tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -13,7 +13,7 @@
     <!-- Purposefully leaving an old version of netcoreapp to ensure we have compatibility. This never gets published -->
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
 
@@ -34,7 +34,7 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <ProjectReference Include="..\dbup-sqlce\dbup-sqlce.csproj" />
     <ProjectReference Include="..\dbup-firebird\dbup-firebird.csproj" />
     <ProjectReference Include="..\dbup-sqlanywhere\dbup-sqlanywhere.csproj" />


### PR DESCRIPTION
Perform a heap of clean up of the build & release actions along with their associated scripts.

- Remove final vestiges of .NET Core 2.0
- Move away from deprecated Cake Tasks for .NET Core
- Alter the CI build to create a GitHub Release in "Draft" mode on any `master` branch build
- Add an additional GitHub Action definition that will trigger when a GitHub Release is published to automatically publish any attached NuGet packages to the NuGet service.