### PR TITLE
Azure SQL Server and Oracle Connection Clean Ups

### DIFF
--- a/Release Notes.md
+++ b/Release Notes.md
@@ -1,0 +1,14 @@
+**Breaking Changes:**
+
+ - Remove Unsupported Target Frameworks (PR #655)
+   - Removed .NET Framework 3.5 and .NET Framework 4.5
+   - Added .NET Framework 4.6.2
+
+ - "Microsoft.Data.SqlClient" used for .NET 6 targets (target framework `net6.0`) instead of "System.Data.SqlClient"
+ 
+**Fixes / Changes:**
+
+ - NuGet packages were improved with Source Link and deterministic builds (PR #624)
+ - EnsureDatabase.For.PostgresqlDatabase database does not exists error (Issue #619)
+ - `dbup-redshift` project was moved to it's own repository at https://github.com/DbUp/dbup-redshift
+ - Patches SqlClient security vulnerability (PR #654)

--- a/src/dbup-oracle/OracleCommandSplitter.cs
+++ b/src/dbup-oracle/OracleCommandSplitter.cs
@@ -13,12 +13,12 @@ namespace DbUp.Oracle
         {
             this.commandReaderFactory = scriptContents => new OracleCommandReader(scriptContents);
         }
-        
+
         public OracleCommandSplitter(char delimiter)
         {
             this.commandReaderFactory = scriptContents => new OracleCustomDelimiterCommandReader(scriptContents, delimiter);
         }
-        
+
         /// <summary>
         /// Splits a script with multiple delimited commands into commands
         /// </summary>

--- a/src/dbup-oracle/OracleConnectionManager.cs
+++ b/src/dbup-oracle/OracleConnectionManager.cs
@@ -10,16 +10,21 @@ namespace DbUp.Oracle
         private readonly OracleCommandSplitter commandSplitter;
 
         /// <summary>
-        /// Creates a new Oracle database connection.
+        /// Creates a new Oracle database connection manager.
         /// </summary>
         /// <param name="connectionString">The Oracle connection string.</param>
-        [Obsolete]
+        [Obsolete("Use OracleConnectionManager(string, OracleCommandSplitter) and supply an appropriate command splitter instance.")]
         public OracleConnectionManager(string connectionString)
             : this(connectionString, new OracleCommandSplitter())
         {
             Console.WriteLine();
         }
-        
+
+        /// <summary>
+        /// Creates a new Oracle database connection manager.
+        /// </summary>
+        /// <param name="connectionString">The Oracle connection string.</param>
+        /// <param name="commandSplitter">A class that splits a string into individual Oracle SQL statements.</param>
         public OracleConnectionManager(string connectionString, OracleCommandSplitter commandSplitter)
             : base(new DelegateConnectionFactory(l => new OracleConnection(connectionString)))
         {

--- a/src/dbup-oracle/OracleExtensions.cs
+++ b/src/dbup-oracle/OracleExtensions.cs
@@ -5,9 +5,26 @@ using DbUp.Engine.Transactions;
 
 namespace DbUp.Oracle
 {
+#pragma warning disable IDE0060 // Remove unused parameter - The "SupportedDatabases" parameter is never used.
     public static class OracleExtensions
     {
-        [Obsolete("Use OracleDatabaseWithSlashDelimiter, OracleDatabaseWithSemicolonDelimiter or the OracleDatabase with the delimiter parameter instead, see https://github.com/DbUp/DbUp/pull/335")]
+        /// <summary>
+        /// Create an upgrader for Oracle databases.
+        /// </summary>
+        /// <param name="supported">Fluent helper type.</param>
+        /// <param name="connectionString">The connection string.</param>
+        /// <returns>
+        /// A builder for a database upgrader designed for Oracle databases.
+        /// </returns>
+        /// <remarks>
+        /// This method is obsolete. One of these should be used instead:
+        /// <list type="bullet">
+        /// <item><see cref="OracleDatabaseWithDefaultDelimiter(SupportedDatabases, string)"/></item>
+        /// <item><see cref="OracleDatabaseWithSemicolonDelimiter(SupportedDatabases, string)"/></item>
+        /// <item><see cref="OracleDatabase(SupportedDatabases, string, char)"/></item>
+        /// </list>
+        /// </remarks>
+        [Obsolete("Use OracleDatabaseWithDefaultDelimiter, OracleDatabaseWithSemicolonDelimiter or the OracleDatabase with the delimiter parameter instead, see https://github.com/DbUp/DbUp/pull/335")]
         public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, string connectionString)
         {
             foreach (var pair in connectionString.Split(';').Select(s => s.Split('=')).Where(pair => pair.Length == 2).Where(pair => pair[0].ToLower() == "database"))
@@ -19,24 +36,36 @@ namespace DbUp.Oracle
         }
 
         /// <summary>
-        /// Use / as the delimiter between statements
+        /// Create an upgrader for Oracle databases that uses the <c>/</c> character as the delimiter between statements.
         /// </summary>
-        /// <param name="supported"></param>
-        /// <param name="connectionString"></param>
-        /// <returns></returns>
+        /// <param name="supported">Fluent helper type.</param>
+        /// <param name="connectionString">The connection string.</param>
+        /// <returns>
+        /// A builder for a database upgrader designed for Oracle databases.
+        /// </returns>
         public static UpgradeEngineBuilder OracleDatabaseWithDefaultDelimiter(this SupportedDatabases supported, string connectionString)
             => OracleDatabase(supported, connectionString, '/');
 
         /// <summary>
-        /// Use ; as the delimiter between statements
+        /// Create an upgrader for Oracle databases that uses the <c>;</c> character as the delimiter between statements.
         /// </summary>
-        /// <param name="supported"></param>
-        /// <param name="connectionString"></param>
-        /// <returns></returns>
+        /// <param name="supported">Fluent helper type.</param>
+        /// <param name="connectionString">The connection string.</param>
+        /// <returns>
+        /// A builder for a database upgrader designed for Oracle databases.
+        /// </returns>
         public static UpgradeEngineBuilder OracleDatabaseWithSemicolonDelimiter(this SupportedDatabases supported, string connectionString)
             => OracleDatabase(supported, connectionString, ';');
 
-#pragma warning disable IDE0060 // Remove unused parameter
+        /// <summary>
+        /// Create an upgrader for Oracle databases.
+        /// </summary>
+        /// <param name="supported">Fluent helper type.</param>
+        /// <param name="connectionString">The connection string.</param>
+        /// <param name="delimiter">Character to use as the delimiter between statements.</param>
+        /// <returns>
+        /// A builder for a database upgrader designed for Oracle databases.
+        /// </returns>
         public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, string connectionString, char delimiter)
         {
             foreach (var pair in connectionString.Split(';').Select(s => s.Split('=')).Where(pair => pair.Length == 2).Where(pair => pair[0].ToLower() == "database"))
@@ -46,7 +75,20 @@ namespace DbUp.Oracle
 
             return OracleDatabase(new OracleConnectionManager(connectionString, new OracleCommandSplitter(delimiter)));
         }
-#pragma warning restore IDE0060 // Remove unused parameter
+
+        /// <summary>
+        /// Create an upgrader for Oracle databases.
+        /// </summary>
+        /// <param name="supported">Fluent helper type.</param>
+        /// <param name="connectionString">The connection string.</param>
+        /// <param name="delimiter">Character to use as the delimiter between statements.</param>
+        /// <returns>
+        /// A builder for a database upgrader designed for Oracle databases.
+        /// </returns>
+        public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, string connectionString, string schema, char delimiter)
+        {
+            return OracleDatabase(new OracleConnectionManager(connectionString, new OracleCommandSplitter(delimiter)), schema);
+        }
 
         /// <summary>
         /// Creates an upgrader for Oracle databases.
@@ -72,12 +114,19 @@ namespace DbUp.Oracle
         /// <returns>
         /// A builder for a database upgrader designed for Oracle databases.
         /// </returns>
-#pragma warning disable IDE0060 // Remove unused parameter
+        /// <remarks>
+        /// This method is obsolete. One of these should be used instead:
+        /// <list type="bullet">
+        /// <item><see cref="OracleDatabaseWithDefaultDelimiter(SupportedDatabases, string)"/></item>
+        /// <item><see cref="OracleDatabaseWithSemicolonDelimiter(SupportedDatabases, string)"/></item>
+        /// <item><see cref="OracleDatabase(SupportedDatabases, string, char)"/></item>
+        /// </list>
+        /// </remarks>
+        [Obsolete("Use OracleDatabaseWithDefaultDelimiter, OracleDatabaseWithSemicolonDelimiter or the OracleDatabase with the delimiter parameter instead, see https://github.com/DbUp/DbUp/pull/335")]
         public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, string connectionString, string schema, string delimiter)
         {
             return OracleDatabase(new OracleConnectionManager(connectionString), schema);
         }
-#pragma warning restore IDE0060 // Remove unused parameter
 
         /// <summary>
         /// Creates an upgrader for Oracle databases.
@@ -87,12 +136,10 @@ namespace DbUp.Oracle
         /// <returns>
         /// A builder for a database upgrader designed for Oracle databases.
         /// </returns>
-#pragma warning disable IDE0060 // Remove unused parameter
         public static UpgradeEngineBuilder OracleDatabase(this SupportedDatabases supported, IConnectionManager connectionManager)
         {
             return OracleDatabase(connectionManager);
         }
-#pragma warning restore IDE0060 // Remove unused parameter
 
         /// <summary>
         /// Creates an upgrader for Oracle databases.
@@ -124,4 +171,5 @@ namespace DbUp.Oracle
             return builder;
         }
     }
+#pragma warning restore IDE0060 // Remove unused parameter
 }

--- a/src/dbup-sqlserver/AzureSqlConnectionManager.cs
+++ b/src/dbup-sqlserver/AzureSqlConnectionManager.cs
@@ -1,5 +1,11 @@
 ﻿using System.Collections.Generic;
+
+#if SUPPORTS_MICROSOFT_SQL_CLIENT
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
+
 using DbUp.Engine.Transactions;
 using DbUp.Support;
 

--- a/src/dbup-sqlserver/AzureSqlServerExtensions.cs
+++ b/src/dbup-sqlserver/AzureSqlServerExtensions.cs
@@ -8,6 +8,7 @@ using DbUp.SqlServer;
 // NOTE: DO NOT MOVE THIS TO A NAMESPACE
 // Since the class just contains extension methods, we leave it in the global:: namespace so that it is always available
 // ReSharper disable CheckNamespace
+#pragma warning disable CA1050 // Declare types in namespaces
 public static class AzureSqlServerExtensions
 {
     /// <summary>Creates an upgrader for Azure SQL Databases using Azure AD Integrated Security.</summary>
@@ -43,5 +44,6 @@ public static class AzureSqlServerExtensions
         return supported.SqlDatabase(new AzureSqlConnectionManager(connectionString, resource, tenantId, azureAdInstance), schema);
     }
 }
+#pragma warning restore CA1050 // Declare types in namespaces
 
 #endif

--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 #if SUPPORTS_MICROSOFT_SQL_CLIENT
 using Microsoft.Data.SqlClient;
 #else
@@ -7,9 +6,6 @@ using System.Data.SqlClient;
 #endif
 using DbUp.Engine.Transactions;
 using DbUp.Support;
-#if SUPPORTS_AZURE_AD
-using Microsoft.Azure.Services.AppAuthentication;
-#endif
 
 namespace DbUp.SqlServer
 {
@@ -33,30 +29,6 @@ namespace DbUp.SqlServer
                  return conn;
              }))
         { }
-
-#if SUPPORTS_AZURE_AD
-        /// <summary>
-        /// Manages Sql Database Connections
-        /// </summary>
-        /// <param name="connectionString"></param>
-        /// <param name="useAzureSqlIntegratedSecurity">Whether to use Azure SQL Integrated Sercurity</param>
-        [Obsolete("Use the \"AzureSqlDatabaseWithIntegratedSecurity\" extension method instead")]
-        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity)
-            : base(new DelegateConnectionFactory((log, dbManager) =>
-            {
-                var conn = new SqlConnection(connectionString);
-
-                if (useAzureSqlIntegratedSecurity)
-                    conn.AccessToken = new AzureServiceTokenProvider().GetAccessTokenAsync("https://database.windows.net/").ConfigureAwait(false).GetAwaiter().GetResult();
-
-                if (dbManager.IsScriptOutputLogged)
-                    conn.InfoMessage += (sender, e) => log.WriteInformation($"{{0}}", e.Message);
-
-                return conn;
-            }))
-        {
-        }
-#endif
 
         public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
         {

--- a/src/dbup-sqlserver/SqlServerExtensions.cs
+++ b/src/dbup-sqlserver/SqlServerExtensions.cs
@@ -17,6 +17,7 @@ using DbUp.SqlServer;
 // NOTE: DO NOT MOVE THIS TO A NAMESPACE
 // Since the class just contains extension methods, we leave it in the global:: namespace so that it is always available
 // ReSharper disable CheckNamespace
+#pragma warning disable CA1050 // Declare types in namespaces
 public static class SqlServerExtensions
 // ReSharper restore CheckNamespace
 {

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -23,10 +23,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Data" />
     <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
@@ -35,11 +32,12 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
   </ItemGroup>
     
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -46,11 +46,11 @@
     <DefineConstants>$(DefineConstants);SUPPORTS_SQL_CONTEXT;SUPPORTS_AZURE_AD</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net6.0'">
     <DefineConstants>$(DefineConstants);SUPPORTS_AZURE_AD</DefineConstants>
   </PropertyGroup>
   
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
      <DefineConstants>$(DefineConstants);SUPPORTS_MICROSOFT_SQL_CLIENT</DefineConstants>
   </PropertyGroup>
 

--- a/src/dbup-tests/Support/Oracle/ApprovalFiles/dbup-oracle.approved.cs
+++ b/src/dbup-tests/Support/Oracle/ApprovalFiles/dbup-oracle.approved.cs
@@ -17,7 +17,7 @@ namespace DbUp.Oracle
     }
     public class OracleConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
-        [System.ObsoleteAttribute()]
+        [System.ObsoleteAttribute("Use OracleConnectionManager(string, OracleCommandSplitter) and supply an appropriate command splitter instance.")]
         public OracleConnectionManager(string connectionString) { }
         public OracleConnectionManager(string connectionString, DbUp.Oracle.OracleCommandSplitter commandSplitter) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
@@ -31,13 +31,15 @@ namespace DbUp.Oracle
     public static class OracleExtensions
     {
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
-        [System.ObsoleteAttribute("Use OracleDatabaseWithSlashDelimiter, OracleDatabaseWithSemicolonDelimiter or the OracleDatabase with the delimiter parameter instead, see https://github.com/DbUp/DbUp/pull/335")]
+        [System.ObsoleteAttribute("Use OracleDatabaseWithDefaultDelimiter, OracleDatabaseWithSemicolonDelimiter or the OracleDatabase with the delimiter parameter instead, see https://github.com/DbUp/DbUp/pull/335")]
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema) { }
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, char delimiter) { }
         [System.ObsoleteAttribute("Use the parameter that takes a delimiter instead, see https://github.com/DbUp/DbUp/pull/335")]
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
+        public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, char delimiter) { }
+        [System.ObsoleteAttribute("Use OracleDatabaseWithDefaultDelimiter, OracleDatabaseWithSemicolonDelimiter or the OracleDatabase with the delimiter parameter instead, see https://github.com/DbUp/DbUp/pull/335")]
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, string delimiter) { }
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabaseWithDefaultDelimiter(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
         public static DbUp.Builder.UpgradeEngineBuilder OracleDatabaseWithSemicolonDelimiter(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }

--- a/src/dbup-tests/Support/SqlServer/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
+++ b/src/dbup-tests/Support/SqlServer/ApprovalFiles/dbup-sqlserver.netcore.approved.cs
@@ -47,8 +47,6 @@ namespace DbUp.SqlServer
     public class SqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
         public SqlConnectionManager(string connectionString) { }
-        [System.ObsoleteAttribute("Use the "AzureSqlDatabaseWithIntegratedSecurity" extension method instead")]
-        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class SqlScriptExecutor : DbUp.Support.ScriptExecutor, DbUp.Engine.IScriptExecutor
@@ -75,7 +73,7 @@ namespace DbUp.SqlServer.Helpers
     public class TemporarySqlDatabase : System.IDisposable
     {
         public TemporarySqlDatabase(string name) { }
-        public TemporarySqlDatabase(System.Data.SqlClient.SqlConnectionStringBuilder connectionStringBuilder) { }
+        public TemporarySqlDatabase(Microsoft.Data.SqlClient.SqlConnectionStringBuilder connectionStringBuilder) { }
         public TemporarySqlDatabase(string name, string instanceName) { }
         public DbUp.Helpers.AdHocSqlRunner AdHoc { get; }
         public string ConnectionString { get; }

--- a/src/dbup-tests/Support/SqlServer/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
+++ b/src/dbup-tests/Support/SqlServer/ApprovalFiles/dbup-sqlserver.netfx.approved.cs
@@ -48,8 +48,6 @@ namespace DbUp.SqlServer
     public class SqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager, DbUp.Engine.Transactions.IConnectionManager
     {
         public SqlConnectionManager(string connectionString) { }
-        [System.ObsoleteAttribute("Use the "AzureSqlDatabaseWithIntegratedSecurity" extension method instead")]
-        public SqlConnectionManager(string connectionString, bool useAzureSqlIntegratedSecurity) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class SqlScriptExecutor : DbUp.Support.ScriptExecutor, DbUp.Engine.IScriptExecutor


### PR DESCRIPTION
Various cleaning up around Azure SQL Server and Oracle connections.

- Include the `SUPPORTS_AZURE_AD` build constant for `net6.0` target framework builds
- Add `Microsoft.Azure.Services.AppAuthentication` package for `net6.0` target framework
- Use latest version of `Microsoft.Azure.Services.AppAuthentication` package
- Remove obsolete `SqlConnectionManager` constructor
- Mark `OracleConnectionManager` constructor that was not using the delimiter properly as obsolete
- Add additional documentation comments

Resolves #660 