### PR TITLE
Rev Versions around .NET/Github Actions/MySQL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           fetch-depth: 0 # all
 
-      - name: Setup .NET 6.0
-        uses: actions/setup-dotnet@v1
+      - name: Setup .NET 7.0
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
 
       - name: Install SQL CE 📅
         shell: powershell

--- a/src/dbup-mysql/dbup-mysql.csproj
+++ b/src/dbup-mysql/dbup-mysql.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="MySql.Data" Version="6.10.6" />
+    <PackageReference Include="MySql.Data" Version="8.0.31" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dbup-mysql/dbup-mysql.csproj
+++ b/src/dbup-mysql/dbup-mysql.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="MySql.Data" Version="6.10.6" />
+    <PackageReference Include="MySql.Data" Version="6.10.9" />
    </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/dbup-mysql/dbup-mysql.csproj
+++ b/src/dbup-mysql/dbup-mysql.csproj
@@ -30,7 +30,11 @@
     <!-- last version to support < .NET 4.5.2. -->
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
+   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="MySql.Data" Version="6.10.6" />
+   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="MySql.Data" Version="8.0.31" />
   </ItemGroup>
 


### PR DESCRIPTION
Minor tweaks to update part of the toolchain. All backwards compatible, but sitting on Latest where possible.

- Build with .NET 7 now that it is GA (6.0 -> 7.0)
- Update SetupDotnet GHA to latest version (1 -> 3)
- Update to support MySQL Data ^8  - this involved conditional dependency tracking for net standard 1.3 as MySQL has dropped that support for the ^8  #series

I believe this also resolves issue #653 