### PR TITLE
Fix for issue/bug #691 (making firebird integration work again)

### DIFF
--- a/src/dbup-core/Engine/Transactions/AllowedTransactionMode.cs
+++ b/src/dbup-core/Engine/Transactions/AllowedTransactionMode.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace DbUp.Engine.Transactions
+{
+    /// <summary>
+    /// makes it possible to set up the TransactionModes allowed for a Database provider
+    /// </summary>
+    [Flags]
+    public enum AllowedTransactionMode
+    {
+        None = 0,
+
+        /// <summary>
+        /// Its allowed to run single transactions for an entire run
+        /// </summary>
+        SingleTransaction = 1,
+        /// <summary>
+        /// Its allowed to run transactions pr. script
+        /// </summary>
+        TransactionPerScript = 2,
+        /// <summary>
+        /// Its allowed to run a single transaction that rolls back at the end
+        /// </summary>
+        SingleTransactionAlwaysRollback = 4,
+
+        All = SingleTransaction | TransactionPerScript | SingleTransactionAlwaysRollback 
+    }
+}

--- a/src/dbup-core/Engine/Transactions/DatabaseConnectionManager.cs
+++ b/src/dbup-core/Engine/Transactions/DatabaseConnectionManager.cs
@@ -16,6 +16,9 @@ namespace DbUp.Engine.Transactions
         IDbConnection upgradeConnection;
         IConnectionFactory connectionFactoryOverride;
 
+        //The allowed TransactionModes
+        protected virtual AllowedTransactionMode AllowedTransactionModes => AllowedTransactionMode.All;
+
         /// <summary>
         /// Manages Database Connections
         /// </summary>
@@ -49,6 +52,8 @@ namespace DbUp.Engine.Transactions
                 upgradeConnection.Open();
             if (transactionStrategy != null)
                 throw new InvalidOperationException("OperationStarting is meant to be called by DbUp and can only be called once");
+            if (!IsAllowed(TransactionMode))
+                throw new InvalidOperationException($"TransactionMode {TransactionMode} is not allowed for {GetType().Name}. Allowed modes are {AllowedTransactionModes}");
             transactionStrategy = transactionStrategyFactory[TransactionMode]();
             transactionStrategy.Initialise(upgradeConnection, upgradeLog, executedScripts);
 
@@ -59,6 +64,21 @@ namespace DbUp.Engine.Transactions
                 transactionStrategy = null;
                 upgradeConnection = null;
             });
+        }
+
+        private bool IsAllowed(TransactionMode mode)
+        {
+            switch (mode)
+            {
+                case TransactionMode.SingleTransaction:
+                    return AllowedTransactionModes.HasFlag(AllowedTransactionMode.SingleTransaction);
+                case TransactionMode.SingleTransactionAlwaysRollback:
+                    return AllowedTransactionModes.HasFlag(AllowedTransactionMode.SingleTransactionAlwaysRollback);
+                case TransactionMode.TransactionPerScript:
+                    return AllowedTransactionModes.HasFlag(AllowedTransactionMode.TransactionPerScript);
+                default:
+                    return true;
+            }
         }
 
         /// <summary>

--- a/src/dbup-firebird/FirebirdConnectionManager.cs
+++ b/src/dbup-firebird/FirebirdConnectionManager.cs
@@ -34,5 +34,7 @@ namespace DbUp.Firebird
 
             return scriptStatements;
         }
+
+        protected override AllowedTransactionMode AllowedTransactionModes => AllowedTransactionMode.TransactionPerScript;
     }
 }

--- a/src/dbup-firebird/FirebirdScriptExecutor.cs
+++ b/src/dbup-firebird/FirebirdScriptExecutor.cs
@@ -33,6 +33,12 @@ namespace DbUp.Firebird
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// We have to run the JournalTable creation and updating of the Journal table in different transactions.
+        /// See this: https://stackoverflow.com/questions/66537195/i-cant-run-inserts-in-firebird-2-5-table-unknown
+        /// </summary>
+        protected override bool UseTheSameTransactionForJournalTableAndScripts => false;
+
         protected override void ExecuteCommandsWithinExceptionHandler(int index, SqlScript script, Action executeCommand)
         {
             try

--- a/src/dbup-firebird/FirebirdTableJournal.cs
+++ b/src/dbup-firebird/FirebirdTableJournal.cs
@@ -29,10 +29,10 @@ namespace DbUp.Firebird
             return $@"CREATE SEQUENCE {GeneratorName(tableName)}";
         }
 
-        static string CreateTriggerSql(string tableName)
+        string CreateTriggerSql(string tableName)
         {
             return
-$@"CREATE TRIGGER {TriggerName(tableName)} FOR {tableName} ACTIVE BEFORE INSERT POSITION 0 AS BEGIN
+$@"CREATE TRIGGER {TriggerName(tableName)} FOR {FqSchemaTableName} ACTIVE BEFORE INSERT POSITION 0 AS BEGIN
     if (new.schemaversionsid is null or (new.schemaversionsid = 0)) then new.schemaversionsid = gen_id({GeneratorName(tableName)},1);
 END;";
         }


### PR DESCRIPTION
Here a some fixes for the firebird provider. I am the original creator of that provider 9 years ago. Unfortunately it has been deteriorating ever since and now it no longer works with Transactions and also it no longer works with the default JournalTable.

This is all fixed in this PR.

As mentioned in the bug the firebird trigger created by `CreateTriggerSql` did not work with or without a transaction. This has been fixed in that method.

Furthermore it is not allowed to Create the journal table and write to it within the same transaction in firebird as explained here:
https://stackoverflow.com/questions/66537195/i-cant-run-inserts-in-firebird-2-5-table-unknown
It fails everytime when a new database with no scripts and no journal tables is used.

This is fixed by using the new bool UseTheSameTransactionForJournalTableAndScripts which is by default true (i.e keeping the normal behaviour) but false for the FirebirdScriptExecutor

The fix works for TransactionPerScript but naturally not when using a single transaction for all scripts. That is why is now disallowed for Firebird by using the new AllowedTransactionModes Flag enum. Default is "All" but for Firebird only TransactionPerScript and no transactions is allowed.

BTW: The fixes have all been tested extensively on a firebird 3.0.10 server

When merged closes #691 
