### PR TITLE
Split CI Workflow in two different Workflows. One for CI and one for release

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -1,10 +1,9 @@
 name: CI Pull Requests
 
 on:
-  push:
+  pull_request:
     branches:
       - master
-  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -39,7 +38,7 @@ jobs:
 
       - name: Test Report 🧪
         uses: dorny/test-reporter@v1
-        if: success() || failure()    # run this step even if previous step failed
+        if: success() || failure() # run this step even if previous step failed
         with:
           name: Tests
           path: artifacts/TestResults/*.trx

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Pull Requests
 
 on:
   push:
@@ -36,22 +36,6 @@ jobs:
         env:
           OCTOVERSION_CurrentBranch: ${{ github.ref }}
           AssentNonInteractive: true
-
-      - name: Push NuGet packages to GitHub Packages ⬆️
-        if: ${{ format('{0}', env.PACKAGE_KEY) != '' }}
-        working-directory: artifacts
-        run: dotnet nuget push *.nupkg --api-key ${{ env.PACKAGE_KEY }} --source "https://nuget.pkg.github.com/DbUp/index.json"
-        env:
-            PACKAGE_KEY: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 'Create Draft Release'
-        if: ${{ format('{0}', github.ref_name) == 'master' && format('{0}', env.GITHUB_TOKEN) != '' }}
-        shell: pwsh
-        working-directory: artifacts
-        # Can't just use wildcard in this command due to https://github.com/cli/cli/issues/5099 so use Get-Item
-        run: gh release create --draft --title "${{ steps.cake-build.outputs.Version_Info_SemVer }}" "${{ steps.cake-build.outputs.Version_Info_SemVer }}" (Get-Item *.nupkg)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test Report 🧪
         uses: dorny/test-reporter@v1

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -1,9 +1,9 @@
-name: Create Draft Release 
+name: Create Draft Release
 
 on:
-  push:
+  pull_request:
     branches:
-      - 'releases/**'
+      - "releases/**"
   workflow_dispatch:
 
 jobs:
@@ -41,9 +41,9 @@ jobs:
         working-directory: artifacts
         run: dotnet nuget push *.nupkg --api-key ${{ env.PACKAGE_KEY }} --source "https://nuget.pkg.github.com/DbUp/index.json"
         env:
-            PACKAGE_KEY: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE_KEY: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'Create Draft Release'
+      - name: "Create Draft Release"
         if: ${{ format('{0}', github.ref_name) == 'master' && format('{0}', env.GITHUB_TOKEN) != '' }}
         shell: pwsh
         working-directory: artifacts
@@ -54,7 +54,7 @@ jobs:
 
       - name: Test Report 🧪
         uses: dorny/test-reporter@v1
-        if: success() || failure()    # run this step even if previous step failed
+        if: success() || failure() # run this step even if previous step failed
         with:
           name: Tests
           path: artifacts/TestResults/*.trx

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -1,0 +1,61 @@
+name: Create Draft Release 
+
+on:
+  push:
+    branches:
+      - 'releases/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true # Avoid pre-populating the NuGet package cache
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # all
+
+      - name: Setup .NET 7.0
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+
+      - name: Install SQL CE 📅
+        shell: powershell
+        run: ./install-sql-ce.ps1
+
+      - name: Cake Build 🏗️
+        id: cake-build
+        shell: powershell
+        run: ./build.ps1
+        env:
+          OCTOVERSION_CurrentBranch: ${{ github.ref }}
+          AssentNonInteractive: true
+
+      - name: Push NuGet packages to GitHub Packages ⬆️
+        if: ${{ format('{0}', env.PACKAGE_KEY) != '' }}
+        working-directory: artifacts
+        run: dotnet nuget push *.nupkg --api-key ${{ env.PACKAGE_KEY }} --source "https://nuget.pkg.github.com/DbUp/index.json"
+        env:
+            PACKAGE_KEY: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Create Draft Release'
+        if: ${{ format('{0}', github.ref_name) == 'master' && format('{0}', env.GITHUB_TOKEN) != '' }}
+        shell: pwsh
+        working-directory: artifacts
+        # Can't just use wildcard in this command due to https://github.com/cli/cli/issues/5099 so use Get-Item
+        run: gh release create --draft --title "${{ steps.cake-build.outputs.Version_Info_SemVer }}" "${{ steps.cake-build.outputs.Version_Info_SemVer }}" (Get-Item *.nupkg)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test Report 🧪
+        uses: dorny/test-reporter@v1
+        if: success() || failure()    # run this step even if previous step failed
+        with:
+          name: Tests
+          path: artifacts/TestResults/*.trx
+          reporter: dotnet-trx


### PR DESCRIPTION
On each pull request the _ci_ workflow fails. It looks like it fails of insufficant rights of the user who is creating the pull request.
<img width="1174" alt="image" src="https://github.com/DbUp/DbUp/assets/7187699/22e0f61b-e2a1-4933-ad7c-d91331ab9eba">
 
 So i split the workflow. One workflow for ci and one workflow for _create draft release_. The draft-release workflow looks for pull requestes on_releases/**_ branch. This has to check, if we use _releases_ branches in the future. 