### PR TITLE
Split Workflows

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -1,5 +1,8 @@
 name: Create Draft Release
 
+# The use of this workflow is to trigger it temporary.
+# In a later step this workflow should be merged back to workflow -Test Code-.
+
 on:
   push:
     tags:
@@ -14,6 +17,11 @@ jobs:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true # Avoid pre-populating the NuGet package cache
+
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    permissions:
+      checks: write #test-reporter https://github.com/dorny/test-reporter/issues/229
+      packages: write
 
     steps:
       - uses: actions/checkout@v3
@@ -35,13 +43,6 @@ jobs:
         run: ./build.ps1
         env:
           OCTOVERSION_CurrentBranch: ${{ github.ref }}
-
-      - name: Push NuGet packages to GitHub Packages ⬆️
-        if: ${{ format('{0}', env.PACKAGE_KEY) != '' }}
-        working-directory: artifacts
-        run: dotnet nuget push *.nupkg --api-key ${{ env.PACKAGE_KEY }} --source "https://nuget.pkg.github.com/DbUp/index.json"
-        env:
-          PACKAGE_KEY: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Create Draft Release"
         if: ${{ format('{0}', github.ref_name) == 'master' && format('{0}', env.GITHUB_TOKEN) != '' }}

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -1,5 +1,9 @@
 name: Test Code
 
+# This workflow is for testing the code.
+# Because of failed permissions all steps which are pushing code to github releases or nuget are removed.
+# For creating draft release launch workflow -Create Draft Release- manually.
+
 on:
   pull_request:
     branches:
@@ -20,8 +24,9 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true # Avoid pre-populating the NuGet package cache
 
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
-      checks: write   #test-reporter https://github.com/dorny/test-reporter/issues/229
+      checks: write #test-reporter https://github.com/dorny/test-reporter/issues/229
 
     steps:
       - uses: actions/checkout@v3
@@ -43,15 +48,6 @@ jobs:
         run: ./build.ps1
         env:
           OCTOVERSION_CurrentBranch: ${{ github.ref }}
-
-      - name: "Create Draft Release"
-        if: ${{ format('{0}', github.ref_name) == 'master' && format('{0}', env.GITHUB_TOKEN) != '' }}
-        shell: pwsh
-        working-directory: artifacts
-        # Can't just use wildcard in this command due to https://github.com/cli/cli/issues/5099 so use Get-Item
-        run: gh release create --draft --title "${{ steps.cake-build.outputs.Version_Info_SemVer }}" "${{ steps.cake-build.outputs.Version_Info_SemVer }}" (Get-Item *.nupkg)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test Report 🧪
         uses: dorny/test-reporter@v1


### PR DESCRIPTION
Thanks to @jafin pr #721 the `cake build` is working again.

Now it fails on `Create Draft Release`. 
![image](https://github.com/DbUp/DbUp/assets/7187699/fd7f666c-c8df-4c45-8260-56e4865ff1f6)

It has no permissions for `packages`. I think we can fix this with adding `packages: write` to section `permissions`. See  [Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) and the screenshot.

But i prefer to remove temporary the _create draft release_ from the `Test Code Workflow` because every merge of an pull request will increase the version number. I will check (in next weeks) how to modify the `cake build` script that draft version number get reused. 
