### PR TITLE
Issue #709 - Add project attributes to exclude from nuget pack.

### DIFF
--- a/src/Tests.Common/Tests.Common.csproj
+++ b/src/Tests.Common/Tests.Common.csproj
@@ -5,6 +5,8 @@
     <AssemblyName>DbUp.Tests.Common</AssemblyName>
     <RootNamespace>DbUp.Tests.Common</RootNamespace>
     <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Tested with Cake build and a .nupkg file was not generated for the Tests.Common project.

Closes issue #709.