### PR TITLE
Add option to modify embedded script names via ScriptNameProvider

### DIFF
--- a/src/dbup-core/Builder/StandardExtensions.cs
+++ b/src/dbup-core/Builder/StandardExtensions.cs
@@ -883,6 +883,20 @@ public static class StandardExtensions
     }
 
     /// <summary>
+    /// Adds all scripts found as embedded resources in the given assembly.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="assemblies">The assemblies.</param>
+    /// <param name="configure">Configure the options.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsEmbeddedInAssembly(this UpgradeEngineBuilder builder, Assembly assembly, Action<EmbeddedScriptsOptions> configure)
+    {
+        return WithScriptsEmbeddedInAssemblies(builder, new[] { assembly }, configure);
+    }
+
+    /// <summary>
     /// Adds all scripts found as embedded resources in the given assemblies.
     /// </summary>
     /// <param name="builder">The builder.</param>

--- a/src/dbup-core/Builder/StandardExtensions.cs
+++ b/src/dbup-core/Builder/StandardExtensions.cs
@@ -881,4 +881,30 @@ public static class StandardExtensions
     {
         return WithScripts(builder, new EmbeddedScriptsProvider(assemblies, filter, encoding, sqlScriptOptions));
     }
+
+    /// <summary>
+    /// Adds all scripts found as embedded resources in the given assemblies.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="assemblies">The assemblies.</param>
+    /// <param name="configure">Configure the options.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder WithScriptsEmbeddedInAssemblies(this UpgradeEngineBuilder builder, Assembly[] assemblies, Action<EmbeddedScriptsOptions> configure)
+    {
+        if (configure == null)
+            throw new ArgumentNullException(nameof(configure));
+
+        var options = new EmbeddedScriptsOptions();
+        configure(options);
+
+        return WithScripts(builder, new EmbeddedScriptsProvider(assemblies,
+            options.Filter ?? (s => s.EndsWith(".sql", StringComparison.OrdinalIgnoreCase)),
+            options.ScriptNameProvider ?? (resourceName => resourceName),
+            options.Encoding ?? DbUpDefaults.DefaultEncoding,
+            options.SqlScriptOptions ?? new()
+            ));
+    }
+
 }

--- a/src/dbup-core/ScriptProviders/EmbeddedScriptProvider.cs
+++ b/src/dbup-core/ScriptProviders/EmbeddedScriptProvider.cs
@@ -39,5 +39,18 @@ namespace DbUp.ScriptProviders
         public EmbeddedScriptProvider(Assembly assembly, Func<string, bool> filter, Encoding encoding, SqlScriptOptions sqlScriptOptions) : base(new[] { assembly ?? throw new ArgumentNullException(nameof(assembly)) }, filter, encoding, sqlScriptOptions)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmbeddedScriptProvider"/> class.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <param name="filter">The filter.</param>
+        /// <param name="scriptNameProvider">The script name provider.</param>
+        /// <param name="encoding">The encoding.</param>
+        /// <param name="sqlScriptOptions">The sql script options</param>        
+        public EmbeddedScriptProvider(Assembly assembly, Func<string, bool> filter, Func<string, string> scriptNameProvider, Encoding encoding, SqlScriptOptions sqlScriptOptions) 
+            : base(new[] { assembly ?? throw new ArgumentNullException(nameof(assembly)) }, filter, scriptNameProvider, encoding, sqlScriptOptions)
+        {
+        }
     }
 }

--- a/src/dbup-core/ScriptProviders/EmbeddedScriptsOptions.cs
+++ b/src/dbup-core/ScriptProviders/EmbeddedScriptsOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Text;
+using DbUp.Engine;
+
+namespace DbUp.ScriptProviders
+{
+    public class EmbeddedScriptsOptions
+    {
+        public Func<string, bool> Filter { get; set; }
+        public Func<string, string> ScriptNameProvider { get; set; }
+        public Encoding Encoding { get; set; }
+        public SqlScriptOptions SqlScriptOptions { get; set; }
+    }
+
+}


### PR DESCRIPTION
Solve #166 and #734 

Can use like:

```
// This works if the scrips has a file ending, eg. MyScript.sql
private static string GetFileNameFromResourceName(string resourceName)
        => string.Join('.', resourceName.Split('.').TakeLast(2));

builder.WithScriptsEmbeddedInAssemblies(Assembly.GetExecutingAssembly(), configure => 
{
 configure.ScriptNameProvider = resourceName => GetFileNameFromResourceName(resourceName);
});

```
This extension method follow the same configure logic seen in AspNet, and with this, only one WithScriptsEmbeddedInAssemblies method is needed and is easily extendable with extending EmbeddedScriptsOptions instead of adding new extension methods.