### PR TITLE
add repository URL to nuget packages

### DIFF
--- a/src/DbUp.Console/DbUp.Console.csproj
+++ b/src/DbUp.Console/DbUp.Console.csproj
@@ -14,6 +14,9 @@
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
+  <PropertyGroup>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>

--- a/src/Tests.Common/Tests.Common.csproj
+++ b/src/Tests.Common/Tests.Common.csproj
@@ -7,6 +7,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/src/dbup-core/dbup-core.csproj
+++ b/src/dbup-core/dbup-core.csproj
@@ -14,6 +14,10 @@
     <DefineConstants>$(DefineConstants);LIBLOG_PORTABLE;LIBLOG_PROVIDERS_ONLY;SUPPORTS_LIBLOG</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <DefineConstants>$(DefineConstants);USE_TYPE_INFO</DefineConstants>
   </PropertyGroup>

--- a/src/dbup-firebird/dbup-firebird.csproj
+++ b/src/dbup-firebird/dbup-firebird.csproj
@@ -12,6 +12,10 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="9.1.1" />

--- a/src/dbup-mysql/dbup-mysql.csproj
+++ b/src/dbup-mysql/dbup-mysql.csproj
@@ -12,6 +12,10 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
     <DefineConstants>$(DefineConstants);MY_SQL_DATA_6_9_5</DefineConstants>
   </PropertyGroup>

--- a/src/dbup-oracle/dbup-oracle.csproj
+++ b/src/dbup-oracle/dbup-oracle.csproj
@@ -4,6 +4,10 @@
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
   </ItemGroup>

--- a/src/dbup-postgresql/dbup-postgresql.csproj
+++ b/src/dbup-postgresql/dbup-postgresql.csproj
@@ -12,6 +12,10 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>

--- a/src/dbup-sqlce/dbup-sqlce.csproj
+++ b/src/dbup-sqlce/dbup-sqlce.csproj
@@ -12,6 +12,10 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
   </ItemGroup>

--- a/src/dbup-sqlite/dbup-sqlite.csproj
+++ b/src/dbup-sqlite/dbup-sqlite.csproj
@@ -12,6 +12,10 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RepositoryUrl>https://github.com/DbUp/DbUp.git</RepositoryUrl>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
   </ItemGroup>


### PR DESCRIPTION
I noticed that [renovate](https://github.com/renovatebot/renovate) wasn't setting the source URL or getting the changelogs for any of the `DbUp` packages except for the original obsolete one. Also the source repo link on nuget.org is missing. I think this is the information that's needed to rectify both situations. I couldn't find a way to get this to happen automatically based on the git configuration, so they're all hard-coded. If there's a better way, I'm happy to make the change.

I'll note that I haven't actually tested either issue is fixed by this change, but I'll try to devise an approximation if needed.