### PR TITLE
Replace Microsoft.Azure.Services.AppAuthentication

### DIFF
--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -23,7 +23,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Data" />
     <Reference Include="System" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
@@ -32,12 +32,12 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
Deprecated Microsoft.Azure.Services.AppAuthentication and replaced it with Azure.Identity using a DefaultAzureCredential.
Resolves DbUp/dbup-sqlserver#12 