### PR TITLE
Removed obsolete DatabaseUpgradeResult constructor

### DIFF
--- a/src/dbup-core/Engine/DatabaseUpgradeResult.cs
+++ b/src/dbup-core/Engine/DatabaseUpgradeResult.cs
@@ -13,12 +13,6 @@ public sealed class DatabaseUpgradeResult
     readonly Exception error;
     readonly SqlScript errorScript;
 
-    [Obsolete]
-    public DatabaseUpgradeResult(IEnumerable<SqlScript> scripts, bool successful, Exception error)
-        : this(scripts, successful, error, null)
-    {
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="DatabaseUpgradeResult"/> class.
     /// </summary>

--- a/src/dbup-core/Properties/JetbrainsAnnotations.cs
+++ b/src/dbup-core/Properties/JetbrainsAnnotations.cs
@@ -891,14 +891,6 @@ enum AssertionConditionType
 }
 
 /// <summary>
-/// Indicates that the marked method unconditionally terminates control flow execution.
-/// For example, it could unconditionally throw exception.
-/// </summary>
-[Obsolete("Use [ContractAnnotation('=> halt')] instead")]
-[AttributeUsage(AttributeTargets.Method)]
-sealed class TerminatesProgramAttribute : Attribute;
-
-/// <summary>
 /// Indicates that method is pure LINQ method, with postponed enumeration (like Enumerable.Select,
 /// .Where). This annotation allows inference of [InstantHandle] annotation for parameters
 /// of delegate type by analyzing LINQ method chains.

--- a/src/dbup-tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
@@ -142,8 +142,6 @@ namespace DbUp.Engine
 {
     public sealed class DatabaseUpgradeResult
     {
-        [System.ObsoleteAttribute()]
-        public DatabaseUpgradeResult(System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> scripts, bool successful, System.Exception error) { }
         public DatabaseUpgradeResult(System.Collections.Generic.IEnumerable<DbUp.Engine.SqlScript> scripts, bool successful, System.Exception error, DbUp.Engine.SqlScript errorScript) { }
         public System.Exception Error { get; }
         public DbUp.Engine.SqlScript ErrorScript { get; }


### PR DESCRIPTION
Last of the Obsolete attributes removed for the 6.0.0 release.

```
DatabaseUpgradeResult(IEnumerable<SqlScript> scripts, bool successful, Exception error)
```

