### PR TITLE
fix: change default character delimiter for Variable Substitution

### DIFF
--- a/docs/more-info/variable-substitution.md
+++ b/docs/more-info/variable-substitution.md
@@ -21,12 +21,12 @@ DeployChanges.To
   .WithVariables(myVariables)
 ```
 
-Then in your database script, you need to enclose all variables in ```$``` signs, for example ```$variable$```:
+Then in your database script, you need to enclose all variables in ```!``` signs, for example ```!variable!```:
 
 ```
--- $TestVariable$ $AnotherVariable$
-print '$TestVariable$'
-SELECT * FROM dbo.$TestVariable$
+-- !TestVariable! !AnotherVariable!
+print '!TestVariable!'
+SELECT * FROM dbo.!TestVariable!
 ```
 
 Will result in:
@@ -35,6 +35,6 @@ print 'Value'
 SELECT * FROM dbo.Value
 ```
 
-Variables can only contain letters, digits, `_` and `-`. If there are any other characters between the `$`s it is not treated as a variable. If a variable is found within a script, but not supplied an exception will be thrown unless it is within a comment. Please be aware that the 'schema' variable will be used by [StripSchemaPreprocessor](https://github.com/DbUp/DbUp/blob/main/src/dbup-core/Engine/Preprocessors/StripSchemaPreprocessor.cs) : don't use it!
+Variables can only contain letters, digits, `_` and `-`. If there are any other characters between the `!`s it is not treated as a variable. If a variable is found within a script, but not supplied an exception will be thrown unless it is within a comment. Please be aware that the 'schema' variable will be used by [StripSchemaPreprocessor](https://github.com/DbUp/DbUp/blob/main/src/dbup-core/Engine/Preprocessors/StripSchemaPreprocessor.cs) : don't use it!
 
 **Note:** there is no way to escape variables, if this causes you issues, create a GitHub issue or submit a pull request to allow escaping!

--- a/src/dbup-core/Engine/Preprocessors/VariableSubstitutionSqlParser.cs
+++ b/src/dbup-core/Engine/Preprocessors/VariableSubstitutionSqlParser.cs
@@ -26,7 +26,7 @@ public class VariableSubstitutionSqlParser : SqlParser
     /// Delimiter character for variables.
     /// Defaults to `$` but can be overridden in derived classes.
     /// </summary>
-    protected virtual char VariableDelimiter => '$';
+    protected virtual char VariableDelimiter => '!';
 
     /// <summary>
     /// Replaces variables in the parsed SQL

--- a/src/dbup-tests/DeployChangesBuilderTests.cs
+++ b/src/dbup-tests/DeployChangesBuilderTests.cs
@@ -17,7 +17,7 @@ public class DeployChangesBuilderTests
         var testProvider = new TestProvider("Db");
 
         testProvider.Builder
-            .WithScript("testscript", "$schema$Up $somevar$")
+            .WithScript("testscript", "!schema!Up !somevar!")
             .WithVariable("somevar", "is awesome");
 
         testProvider.Builder.Build().PerformUpgrade();

--- a/src/dbup-tests/Engine/UpgradeEngineTests.cs
+++ b/src/dbup-tests/Engine/UpgradeEngineTests.cs
@@ -28,7 +28,7 @@ public class UpgradeEngineTests
             var connectionManager = new TestConnectionManager(dbConnection);
 
             var builder = new UpgradeEngineBuilder()
-                .WithScript(new SqlScript("1234", "create table $var$ (Id int)"))
+                .WithScript(new SqlScript("1234", "create table !var! (Id int)"))
                 .JournalTo(new NullJournal())
                 .WithVariable("var", "sub");
             builder.Configure(c => c.ScriptExecutor = new TestScriptExecutor(c, "dbo"));

--- a/src/dbup-tests/Engine/VariableSubstitutionPreprocessorTests.cs
+++ b/src/dbup-tests/Engine/VariableSubstitutionPreprocessorTests.cs
@@ -35,7 +35,7 @@ public class VariableSubstitutionPreprocessorTests
 
     [Fact]
     public void substitutes_variables_in_body()
-        => this.Given(_ => _.GivenAScript("something $somevar$ something"))
+        => this.Given(_ => _.GivenAScript("something !somevar! something"))
             .And(_ => GivenAVariable("somevar", "coriander"))
             .When(_ => _.WhenUpgradeIsPerformed())
             .Then(_ => _.ThenTheUpgradeWasSuccessful())
@@ -44,7 +44,7 @@ public class VariableSubstitutionPreprocessorTests
 
     [Fact]
     public void substitutes_variables_in_quoted_text()
-        => this.Given(_ => _.GivenAScript("'$somevar$'"))
+        => this.Given(_ => _.GivenAScript("'!somevar!'"))
             .And(_ => GivenAVariable("somevar", "coriander"))
             .When(_ => _.WhenUpgradeIsPerformed())
             .Then(_ => _.ThenTheUpgradeWasSuccessful())
@@ -53,35 +53,35 @@ public class VariableSubstitutionPreprocessorTests
 
     [Fact]
     public void ignores_undefined_variables_in_comments()
-        => this.Given(_ => _.GivenAScript("/*$somevar$*/"))
+        => this.Given(_ => _.GivenAScript("/*!somevar!*/"))
             .And(_ => GivenAVariable("beansprouts", "coriander"))
             .When(_ => _.WhenUpgradeIsPerformed())
             .Then(_ => _.ThenTheUpgradeWasSuccessful())
-            .And(_ => _.ThenTheCommandWasIssuedWithText("/*$somevar$*/"))
+            .And(_ => _.ThenTheCommandWasIssuedWithText("/*!somevar!*/"))
             .BDDfy();
 
 
     [Fact]
     public void ignores_undefined_variables_in_complex_comments()
-        => this.Given(_ => _.GivenAScript("/*/**/$somevar$*/"))
+        => this.Given(_ => _.GivenAScript("/*/**/!somevar!*/"))
             .And(_ => GivenAVariable("beansprouts", "coriander"))
             .When(_ => _.WhenUpgradeIsPerformed())
             .Then(_ => _.ThenTheUpgradeWasSuccessful())
-            .And(_ => _.ThenTheCommandWasIssuedWithText("/*/**/$somevar$*/"))
+            .And(_ => _.ThenTheCommandWasIssuedWithText("/*/**/!somevar!*/"))
             .BDDfy();
 
     [Fact]
     public void ignores_undefined_variable_in_line_comment()
-        => this.Given(_ => _.GivenAScript("--$somevar$"))
+        => this.Given(_ => _.GivenAScript("--!somevar!"))
             .And(_ => GivenAVariable("beansprouts", "coriander"))
             .When(_ => _.WhenUpgradeIsPerformed())
             .Then(_ => _.ThenTheUpgradeWasSuccessful())
-            .And(_ => _.ThenTheCommandWasIssuedWithText("--$somevar$"))
+            .And(_ => _.ThenTheCommandWasIssuedWithText("--!somevar!"))
             .BDDfy();
 
     [Fact]
     public void throws_for_undefined_variable()
-        => this.Given(_ => _.GivenAScript("$somevar$"))
+        => this.Given(_ => _.GivenAScript("!somevar!"))
             .And(_ => GivenAVariable("beansprouts", "coriander"))
             .When(_ => _.WhenUpgradeIsPerformed())
             .Then(_ => _.ThenTheUpgradeWasUnsuccessful())
@@ -90,20 +90,20 @@ public class VariableSubstitutionPreprocessorTests
 
     [Fact]
     public void ignores_if_whitespace_between_dollars()
-        => this.Given(_ => _.GivenAScript("$some var$"))
+        => this.Given(_ => _.GivenAScript("!some var!"))
             .And(_ => GivenAVariable("some var", "coriander"))
             .When(_ => _.WhenUpgradeIsPerformed())
             .Then(_ => _.ThenTheUpgradeWasSuccessful())
-            .And(_ => _.ThenTheCommandWasIssuedWithText("$some var$"))
+            .And(_ => _.ThenTheCommandWasIssuedWithText("!some var!"))
             .BDDfy();
 
 
     [Fact]
     public void ignores_if_newline_between_dollars()
-        => this.Given(_ => _.GivenAScript("$some\nvar$"))
+        => this.Given(_ => _.GivenAScript("!some\nvar!"))
             .And(_ => GivenAVariable("somevar", "coriander"))
             .When(_ => _.WhenUpgradeIsPerformed())
             .Then(_ => _.ThenTheUpgradeWasSuccessful())
-            .And(_ => _.ThenTheCommandWasIssuedWithText("$some\nvar$"))
+            .And(_ => _.ThenTheCommandWasIssuedWithText("!some\nvar!"))
             .BDDfy();
 }


### PR DESCRIPTION
closes #794 

This is a backwards incompatible change and would require a major version bump, imho.