### PR TITLE
Re-added NoOpUpgradeLog

### DIFF
--- a/src/dbup-core/Builder/StandardExtensions.cs
+++ b/src/dbup-core/Builder/StandardExtensions.cs
@@ -75,7 +75,19 @@ public static class StandardExtensions
         builder.LogTo(new ConsoleUpgradeLog());
         return builder;
     }
-
+    
+    /// <summary>
+    /// Discards all log messages
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <returns>
+    /// The same builder
+    /// </returns>
+    public static UpgradeEngineBuilder LogToNowhere(this UpgradeEngineBuilder builder)
+    {
+        return LogTo(builder, new NoOpUpgradeLog());
+    }
+    
     /// <summary>
     /// Logs to System.Diagnostics.Trace.
     /// </summary>

--- a/src/dbup-core/Engine/Output/MicrosoftUpgradeLog.cs
+++ b/src/dbup-core/Engine/Output/MicrosoftUpgradeLog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -9,24 +10,20 @@ namespace DbUp.Engine.Output
     /// </summary>
     public class MicrosoftUpgradeLog : IUpgradeLog
     {
-        public MicrosoftUpgradeLog(ILoggerFactory loggerFactory = null)
+        public MicrosoftUpgradeLog([NotNull] ILoggerFactory loggerFactory)
         {
-            loggerFactory ??= NullLoggerFactory.Instance;
-            _logger = loggerFactory?.CreateLogger<UpgradeEngine>()
-                      ?? throw new ArgumentNullException(nameof(loggerFactory));
+            if (loggerFactory == null)
+                throw new ArgumentNullException(nameof(loggerFactory));
+
+            _logger = loggerFactory.CreateLogger<UpgradeEngine>();
         }
 
-        public MicrosoftUpgradeLog(ILogger logger)
+        public MicrosoftUpgradeLog([NotNull] ILogger logger)
         {
-            _logger = logger ?? NullLogger.Instance;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        private readonly ILogger _logger;
-
-        /// <summary>
-        /// A logger that does nothing.
-        /// </summary>
-        public static IUpgradeLog DevNull => new Lazy<IUpgradeLog>(() => new MicrosoftUpgradeLog(NullLoggerFactory.Instance)).Value;
+        readonly ILogger _logger;
 
         /// <inheritdoc/>
         public void LogTrace(string message, params object[] args) =>

--- a/src/dbup-core/Engine/Output/NoOpUpgradeLog.cs
+++ b/src/dbup-core/Engine/Output/NoOpUpgradeLog.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace DbUp.Engine.Output;
+
+/// <summary>
+/// A logger that does nothing
+/// </summary>
+public class NoOpUpgradeLog : MicrosoftUpgradeLog
+{
+    public NoOpUpgradeLog()
+        : base(NullLogger.Instance)
+    {
+            
+    }
+}

--- a/src/dbup-tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
@@ -11,6 +11,7 @@ public static class StandardExtensions
     public static DbUp.Builder.UpgradeEngineBuilder LogTo(this DbUp.Builder.UpgradeEngineBuilder builder, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
     public static DbUp.Builder.UpgradeEngineBuilder LogTo(this DbUp.Builder.UpgradeEngineBuilder builder, Microsoft.Extensions.Logging.ILogger logger) { }
     public static DbUp.Builder.UpgradeEngineBuilder LogToConsole(this DbUp.Builder.UpgradeEngineBuilder builder) { }
+    public static DbUp.Builder.UpgradeEngineBuilder LogToNowhere(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder LogToTrace(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder ResetConfiguredLoggers(this DbUp.Builder.UpgradeEngineBuilder builder) { }
     public static DbUp.Builder.UpgradeEngineBuilder WithExecutionTimeout(this DbUp.Builder.UpgradeEngineBuilder builder, System.Nullable<System.TimeSpan> timeout) { }

--- a/src/dbup-tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
+++ b/src/dbup-tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
@@ -289,15 +289,18 @@ namespace DbUp.Engine.Output
     }
     public class MicrosoftUpgradeLog : DbUp.Engine.Output.IUpgradeLog
     {
-        public MicrosoftUpgradeLog(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory = null) { }
+        public MicrosoftUpgradeLog(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         public MicrosoftUpgradeLog(Microsoft.Extensions.Logging.ILogger logger) { }
-        public static DbUp.Engine.Output.IUpgradeLog DevNull { get; }
         public void LogDebug(string message, params object[] args) { }
         public void LogError(string message, params object[] args) { }
         public void LogError(System.Exception ex, string message, params object[] args) { }
         public void LogInformation(string message, params object[] args) { }
         public void LogTrace(string message, params object[] args) { }
         public void LogWarning(string message, params object[] args) { }
+    }
+    public class NoOpUpgradeLog : DbUp.Engine.Output.MicrosoftUpgradeLog, DbUp.Engine.Output.IUpgradeLog
+    {
+        public NoOpUpgradeLog() { }
     }
     public class TraceUpgradeLog : DbUp.Engine.Output.IUpgradeLog
     {

--- a/src/dbup-tests/Builder/UpgradeConfigurationFixture.cs
+++ b/src/dbup-tests/Builder/UpgradeConfigurationFixture.cs
@@ -22,7 +22,7 @@ public class UpgradeConfigurationFixture
     public void Adding_Logger_Increments_Providers()
     {
         var config = new UpgradeConfiguration();
-        config.AddLog(MicrosoftUpgradeLog.DevNull);
+        config.AddLog(new NoOpUpgradeLog());
 
         config.Log.HasLoggers.ShouldBeTrue();
         config.Log.LoggerCount.ShouldBe(1);

--- a/src/dbup-tests/Engine/Output/AggregateLoggingTests.cs
+++ b/src/dbup-tests/Engine/Output/AggregateLoggingTests.cs
@@ -7,7 +7,7 @@ namespace DbUp.Tests.Engine.Output
     {
         /// <inheritdoc/>
         protected override IUpgradeLog CreateLogger()
-            => new AggregateLog(new IUpgradeLog[] {new ConsoleUpgradeLog(), new TraceUpgradeLog(), MicrosoftUpgradeLog.DevNull});
+            => new AggregateLog(new IUpgradeLog[] {new ConsoleUpgradeLog(), new TraceUpgradeLog(), new NoOpUpgradeLog()});
 
         [Fact]
         public void Logs_Silently_When_No_Loggers_Are_Added()

--- a/src/dbup-tests/Engine/Output/DevNullLoggingTests.cs
+++ b/src/dbup-tests/Engine/Output/DevNullLoggingTests.cs
@@ -5,6 +5,6 @@ namespace DbUp.Tests.Engine.Output
     public class DevNullLoggingTests : BaseLoggingTest
     {
         /// <inheritdoc/>
-        protected override IUpgradeLog CreateLogger() => MicrosoftUpgradeLog.DevNull;
+        protected override IUpgradeLog CreateLogger() => new NoOpUpgradeLog();
     }
 }


### PR DESCRIPTION
When upgrading several projects it was hard to discover how to pass a Null logger. This re-instates the previous class and extension method, which means it shows up in intellisense more reddily.

Also removed the ability to pass null to MicrosoftUpgradeLog ctors as it's not obvious what that would do.