### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/src/dbup-core/dbup-core.csproj
+++ b/src/dbup-core/dbup-core.csproj
@@ -21,11 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0"/>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Now that DbUp targets .NET Standard 2.0 exclusively it's no longer necessary to have references to the various Microsoft.* and System.* NuGet packages.
