### PR TITLE
Scope table existence query to current database

### DIFF
--- a/src/dbup-core/Support/TableJournal.cs
+++ b/src/dbup-core/Support/TableJournal.cs
@@ -251,7 +251,7 @@ public abstract class TableJournal : IJournal
     protected virtual string DoesTableExistSql()
     {
         return string.IsNullOrEmpty(SchemaTableSchema)
-            ? $"select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '{UnquotedSchemaTableName}'"
+            ? $"select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '{UnquotedSchemaTableName}' and TABLE_SCHEMA = database()"
             : $"select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '{UnquotedSchemaTableName}' and TABLE_SCHEMA = '{SchemaTableSchema}'";
     }
 }


### PR DESCRIPTION
`information_schema.tables` returns all the tables of all the schemas/databases in the MySQL instance. When using a single instance with multiple applications/databases this query might return the wrong result.

Currently this can be worked around by specifying the schema name at using `JournalToMySqlTable(...)`, but I think using the current database specified in the connection string is a good default when it's not explicitly specified.